### PR TITLE
Two new options for ammo and moving items.

### DIFF
--- a/gamemode/init.lua
+++ b/gamemode/init.lua
@@ -258,7 +258,7 @@ function GM:EntityTakeDamage(target, dmginfo)
 				return true
 			end
 		end
-		
+
 		local dmg = dmginfo:GetDamage()
 		if dmg > 0 then
 			local hitGroup = HITGROUP_GENERIC
@@ -283,6 +283,12 @@ function GM:EntityTakeDamage(target, dmginfo)
 			return true
 		end
 
+	elseif target:IsWeapon() == true or target:IsItem() == true then
+		if lambda_prevent_item_move:GetBool() == true then
+			if (IsValid(attacker) and attacker:IsPlayer()) or (IsValid(inflictor) and inflictor:IsPlayer()) then
+				dmginfo:SetDamageForce(Vector(0, 0, 0))
+			end
+		end 
 	end
 
 	if target.FilterDamage == true then

--- a/gamemode/sh_convars.lua
+++ b/gamemode/sh_convars.lua
@@ -55,3 +55,5 @@ lambda_connect_timeout = GM:RegisterConVar("connect_timeout", 120, bit.bor(0, FC
 lambda_playercollision = GM:RegisterConVar("playercollision", 1, bit.bor(0, FCVAR_ARCHIVE, FCVAR_NOTIFY, FCVAR_REPLICATED), "Enables or disables collisions between players.")
 lambda_friendlyfire = GM:RegisterConVar("friendlyfire", 0, bit.bor(0, FCVAR_ARCHIVE, FCVAR_NOTIFY, FCVAR_REPLICATED), "Enables friendly fire, only works if player collisions enabled.")
 lambda_playertracker = GM:RegisterConVar("player_tracker", 1, bit.bor(0, FCVAR_ARCHIVE, FCVAR_NOTIFY, FCVAR_REPLICATED), "Allows to see players through walls")
+lambda_prevent_item_move = GM:RegisterConVar("weapon_strip_force", 1, bit.bor(0, FCVAR_ARCHIVE, FCVAR_NOTIFY, FCVAR_REPLICATED), "Prevents players from moving weapons and items from by shooting.")
+lambda_limit_default_ammo = GM:RegisterConVar("limit_default_ammo", 1, bit.bor(0, FCVAR_ARCHIVE, FCVAR_NOTIFY, FCVAR_REPLICATED), "If enabled weapons default ammo will use the sk_* settings for max limit.")

--- a/gamemode/sh_lambda_player.lua
+++ b/gamemode/sh_lambda_player.lua
@@ -777,6 +777,10 @@ if SERVER then
 
 	function GM:LimitPlayerAmmo(ply)
 
+		if lambda_limit_default_ammo:GetBool() == false then
+			return
+		end
+
 		local curTime = CurTime()
 
 		ply.LastAmmoCheck = ply.LastAmmoCheck or curTime
@@ -816,6 +820,9 @@ if SERVER then
 	function GM:PlayerCanPickupAmmo(ply, ent, extendSize)
 
 		-- Limit the ammo to pickup based on the sk convars.
+		if lambda_limit_default_ammo:GetBool() == false then
+			return true
+		end
 
 		local res = true
 		local capacity = 0


### PR DESCRIPTION
Add convar to disable ammo limits.
Add convar to prevent weapons moving from damage force.