### PR TITLE
Update env_screenoverlay, and a safe-check to settings menu

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,7 @@
 0.9.18 (in development)
+- Improved: env_screenoverlay now works like behavior from HL2.
+- Fixed: env_screenoverlay causing error on some unexpected cases.
+- Fixed: Open settings menu and close it too fast will leave a slider bar at top of screen.
 
 0.9.17
 - Improved: Addon compatibility, Lambda will attempt to recover if there are conflicts and warns about it.

--- a/gamemode/huds/hud_lambda_player.lua
+++ b/gamemode/huds/hud_lambda_player.lua
@@ -116,6 +116,7 @@ function PANEL:Init()
         HighlightTab(false)
         -- Slight delay to make sure model is set on entity
         timer.Simple(0.1, function()
+            if not nobgLabel:IsValid() then return end
             local ply = LocalPlayer()
             local mdlStr = player_manager.TranslatePlayerModel(lambda_playermdl:GetString())
             local numSkins = NumModelSkins(mdlStr) - 1


### PR DESCRIPTION
This PR improves:
1. Improve env_screenoverlay, make it fit the original behavior (overlay won't disappear until timed out or "StopOverlays" calls).
2. When a env_screenoverlay done his job, but the map didn't call "StopOverlays", it will stay on the player screen forever with last "OverlayName" keyvalue, so I have added a 20 seconds of timeout, after 20 seconds the overlay will be force disabled.

This PR fixes:
1. If there is a "env_screenoverlay" entity and it's keyvalue is "OverlayName1 'effects/tp_eyefx/tpeye'" and "OverlayTime1 '1.0'", after "StartOverlays" being called, the overlay will only showing for 1 second, then disappear. But the entity will stay active even there is no more overlay to show, so "ActiveNum" will start out of control, which will cause [StartScreenOverlay](https://github.com/GMLambda/Lambda/blob/develop/gamemode/sh_lambda_player.lua#L1061) receive nil parameter causing numerous net message error.
2. Player pressing F1 and ESC at same time, settings menu will be closed before the timer execute, causing lua error and leave a bugged "DNumSlider" element until map changes.