### PR TITLE
HL2 mapscript improvement

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,12 +1,12 @@
 0.9.18 (in development)
 - Improved: env_screenoverlay now works like behavior from HL2.
-- Improved: d1_trainstation_05: Breen now have cutscene.
+- Improved: d1_trainstation_05: Breen now plays the expected cutscene.
 - Improved: d3_citadel_03: Reworked confiscation field area to make it process faster.
 - Fixed: env_screenoverlay causing error on some unexpected cases.
 - Fixed: Open settings menu and close it too fast will leave a slider bar at top of screen.
-- Fixed: d2_coast_10: Vehicle not correct removed after parking to the warehouse.
-- Fixed: d3_citadel_03: A lua error at round beginning and a softlock in rare case.
-- Fixed: d3_breen_01: Breen get stuck with the chair, make he a bit slower in the cutscene.
+- Fixed: d2_coast_10: Vehicle not being removed after parking it in the warehouse.
+- Fixed: d3_citadel_03: A lua error at the beginning of the round and a rare potential soft-lock.
+- Fixed: d3_breen_01: Breen can get stuck on the chair making the cutscene a bit slower.
 
 0.9.17
 - Improved: Addon compatibility, Lambda will attempt to recover if there are conflicts and warns about it.

--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,12 @@
 0.9.18 (in development)
 - Improved: env_screenoverlay now works like behavior from HL2.
+- Improved: d1_trainstation_05: Breen now have cutscene.
+- Improved: d3_citadel_03: Reworked confiscation field area to make it process faster.
 - Fixed: env_screenoverlay causing error on some unexpected cases.
 - Fixed: Open settings menu and close it too fast will leave a slider bar at top of screen.
+- Fixed: d2_coast_10: Vehicle not correct removed after parking to the warehouse.
+- Fixed: d3_citadel_03: A lua error at round beginning and a softlock in rare case.
+- Fixed: d3_breen_01: Breen get stuck with the chair, make he a bit slower in the cutscene.
 
 0.9.17
 - Improved: Addon compatibility, Lambda will attempt to recover if there are conflicts and warns about it.

--- a/gamemode/gametypes/hl2/mapscripts/d1_trainstation_05.lua
+++ b/gamemode/gametypes/hl2/mapscripts/d1_trainstation_05.lua
@@ -155,6 +155,27 @@ function MAPSCRIPT:PostInit()
         ents.WaitForEntityByName("mark_alyx_intro", function(ent)
             ent:SetPos(Vector(-6491.843262, -876.207031, 64.031250))
         end)
+
+        -- Breen cutscene
+        local data =
+        {
+            SpawnFlags = 64,
+            Pos = Vector(-13410, -40, 55),
+            KeyValues =
+            {
+                targetname = "Breen_Cutscene",
+                m_iszEntity = "Breen",
+                m_iszEntry = "sit_startle",
+                m_iszPlay = "get_up",
+                m_iszPostIdle = "at_console"
+            }
+        }
+
+        ents.CreateSimple("scripted_sequence", data)
+
+        ents.WaitForEntityByName("t4_breen_destination_rl", function(ent)
+            ent:Fire("AddOutput", "OnTrigger Breen_Cutscene,BeginSequence,,1,1")
+        end)
     end
 end
 

--- a/gamemode/gametypes/hl2/mapscripts/d2_coast_10.lua
+++ b/gamemode/gametypes/hl2/mapscripts/d2_coast_10.lua
@@ -79,6 +79,8 @@ function MAPSCRIPT:PostInit()
             GAMEMODE:SetSpawnPlayerVehicles(false)
             GAMEMODE:SetPlayerCheckpoint(checkpoint1, activator)
             TriggerOutputs({{"garage_exit_trigger", "Enable", 0, ""}, {"greeter_conditions", "Disable", 0, ""}, {"greeter_car_nag_timer", "Kill", 0, ""}, {"garage_door", "Close", 0, ""}, {"greeter_briefing_conditions", "Enable", 0, ""}, {"greeter_wave_timer", "Disable", 0, ""}, {"look_at_player", "Resume", 0, ""}})
+
+            ents.RemoveByClass("prop_vehicle_jeep")
         end
 
         -- 8222.646484 1799.084961 960.000000

--- a/gamemode/gametypes/hl2/mapscripts/d3_breen_01.lua
+++ b/gamemode/gametypes/hl2/mapscripts/d3_breen_01.lua
@@ -104,6 +104,19 @@ function MAPSCRIPT:PostInit()
             ent:Remove()
         end)
 
+        local breenchair = ents.FindByModel("models/props_combine/breenchair.mdl")
+
+        for _, v in ipairs(breenchair) do
+            v:SetPos(Vector(-1972.93, 836.43, 591.45))
+            v:SetAngles(Angle(0.04, -89.85, 0.04))
+
+            -- Make sure it's asleep.
+            local phys = v:GetPhysicsObject()
+            if IsValid(phys) then
+                phys:Sleep()
+            end
+        end
+
         ents.WaitForEntityByName("pod", function(ent)
             local podParent = ent:GetParent()
             local parentAttachment = ent:GetParentAttachment()

--- a/gamemode/gametypes/hl2/mapscripts/d3_citadel_03.lua
+++ b/gamemode/gametypes/hl2/mapscripts/d3_citadel_03.lua
@@ -31,7 +31,7 @@ function MAPSCRIPT:PostInit()
             end
         end
 
-        GAMEMODE:WaitForInput("logic_weapon_strip_strip", "Trigger", function(ent)
+        GAMEMODE:WaitForInput("logic_weapon_strip_strip", "Trigger", function(logic_strip)
             timer.Simple(3.8, function()
                 local ply = nil
                 for _, v in ipairs(player.GetAll()) do

--- a/gamemode/gametypes/hl2/mapscripts/d3_citadel_03.lua
+++ b/gamemode/gametypes/hl2/mapscripts/d3_citadel_03.lua
@@ -32,7 +32,7 @@ function MAPSCRIPT:PostInit()
         end
 
         GAMEMODE:WaitForInput("logic_weapon_strip_strip", "Trigger", function(logic_strip)
-            util.RunDelayed(3.8, function()
+            util.RunDelayed(function()
                 local ply = nil
                 for _, v in ipairs(player.GetAll()) do
                     if v:Alive() then

--- a/gamemode/gametypes/hl2/mapscripts/d3_citadel_03.lua
+++ b/gamemode/gametypes/hl2/mapscripts/d3_citadel_03.lua
@@ -32,7 +32,7 @@ function MAPSCRIPT:PostInit()
         end
 
         GAMEMODE:WaitForInput("logic_weapon_strip_strip", "Trigger", function(logic_strip)
-            timer.Simple(3.8, function()
+            util.RunDelayed(3.8, function()
                 local ply = nil
                 for _, v in ipairs(player.GetAll()) do
                     if v:Alive() then
@@ -56,7 +56,7 @@ function MAPSCRIPT:PostInit()
                         end)
                     end)
                 end
-            end)
+            end, CurTime() + 3.8)
         end)
 
         -- 7724.114746 -1358.596924 2112.031250


### PR DESCRIPTION
This PR improves:
1. d1_trainstation_05: Breen now have cutscene just like in HL2.
2. d3_citadel_03: Reworked weapon strip code, allowing only 1 player to keep the weapons for stripping sequence, so it can process faster, and reduce lag or time-wasting on a large server (15 players or more).
3. d3_citadel_03: Improved the original "only allow one gravity gun exists" code, now it use less code and no longer aiming to player but weapon itself.

This PR fixes:
1. d2_coast_10: Vehicle is still exists even player done parking it to the warehouse. (Multiplayer only)
2. d3_citadel_03: A lua error on round beginning if there is at least 2 players, and this error cause softlock if player is processed from previous map. (Multiplayer only)
4. d3_citadel_03: If a player spawn while stripping, his gravity gun will drop immediately, and there will be multi gravity guns causing softlock. (Multiplayer only)
5. d3_breen_01: Breen get stuck with his chair about 1 sec when he is going to say "Guard! Get in here!", this make him a bit slower with the whole cutscene, which kinda dumb and funny.