### PR TITLE
More HL2 mapscript improvement

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,12 +2,16 @@
 - Improved: env_screenoverlay now works like behavior from HL2.
 - Improved: d1_trainstation_05: Breen now plays the expected cutscene.
 - Improved: d3_citadel_03: Reworked confiscation field area to make it process faster.
+- Improved: d3_c17_10b map script.
 - Fixed: env_screenoverlay causing error on some unexpected cases.
 - Fixed: Open settings menu and close it too fast will leave a slider bar at top of screen.
 - Fixed: d2_coast_10: Vehicle not being removed after parking it in the warehouse.
 - Fixed: d3_citadel_03: A lua error at the beginning of the round and a rare potential soft-lock.
 - Fixed: d3_breen_01: Breen can get stuck on the chair making the cutscene a bit slower.
 - Fixed: Default difficulty is now "Normal" rather than "Very easy"
+- Fixed: d1_canals_07: Metrocop didn't use the turret.
+- Fixed: d3_c17_06b: Player can kill a friendly NPC and probability trigger a soft-lock.
+- Fixed: d3_c17_10b: Player died in laser room, make the map unable to proceed.
 
 0.9.17
 - Improved: Addon compatibility, Lambda will attempt to recover if there are conflicts and warns about it.

--- a/gamemode/gametypes/hl2/mapscripts/d1_canals_07.lua
+++ b/gamemode/gametypes/hl2/mapscripts/d1_canals_07.lua
@@ -33,6 +33,12 @@ function MAPSCRIPT:PostInit()
             GAMEMODE:SetPlayerCheckpoint(checkpoint1, activator)
         end
 
+        -- Tell metrocop use the turret.
+        ents.WaitForEntityByName("logic_room7_spawn_functank_cop", function(ent)
+            ent:Fire("AddOutput", "OnTrigger turret_1,ForceNPCOff,,0.12,-1")
+            ent:Fire("AddOutput", "OnTrigger turret_1,FindNPCToManTank,copturret_1,0.15,-1")
+        end)
+
         -- Subtile rush blocking.
         ents.CreateSimple("prop_physics", {
             Model = "models/props_wasteland/laundry_washer003.mdl",

--- a/gamemode/gametypes/hl2/mapscripts/d3_c17_06b.lua
+++ b/gamemode/gametypes/hl2/mapscripts/d3_c17_06b.lua
@@ -32,6 +32,12 @@ MAPSCRIPT.EntityFilterByName = {
 
 function MAPSCRIPT:PostInit()
     if SERVER then
+        -- This NPC should not can be killed by player.
+        ents.WaitForEntityByName("citizen_2_ct_mkr", function(ent)
+            ent:ClearOutputs()
+            ent:Fire("AddOutput", "OnSpawnNPC citizen_2_ct_aiss_1,StartSchedule,,0.1,1")
+        end)
+
         -- 2894.431396 1052.031250 64.031250
         local checkpoint1 = GAMEMODE:CreateCheckpoint(Vector(2843.645508, 1058.373169, 64.031250), Angle(0, 0, 0))
         checkpoint1:SetVisiblePos(Vector(2904.702881, 1060.976196, 64.031250))

--- a/gamemode/gametypes/hl2/mapscripts/d3_c17_10b.lua
+++ b/gamemode/gametypes/hl2/mapscripts/d3_c17_10b.lua
@@ -24,7 +24,8 @@ MAPSCRIPT.DefaultLoadout = {
 }
 
 MAPSCRIPT.InputFilters = {
-    ["s_room_panelswitch"] = {"Lock"} -- Prevent it from locking the button.
+    ["s_room_panelswitch"] = {"Lock"}, -- Prevent it from locking the button.
+    ["lobby_combinedoor_portalbrush"] = {"Enable"}
 }
 
 MAPSCRIPT.EntityFilterByClass = {}
@@ -43,6 +44,10 @@ function MAPSCRIPT:PostInit()
         checkpointTrigger1.OnTrigger = function(_, activator)
             GAMEMODE:SetPlayerCheckpoint(checkpoint1, activator)
         end
+
+        GAMEMODE:WaitForInput("lobby_combinedoor", "SetAnimation", function()
+            GAMEMODE:FilterEntityInput("lobby_combinedoor", "SetAnimation") -- Don't close the door once it's opened.
+        end)
 
         -- Add another logic relay that disables all turrets once the button is pressed.
         local turretsOffRelay = ents.Create("logic_relay")

--- a/gamemode/gametypes/hl2/mapscripts/d3_c17_10b.lua
+++ b/gamemode/gametypes/hl2/mapscripts/d3_c17_10b.lua
@@ -71,6 +71,13 @@ function MAPSCRIPT:PostInit()
             v:Remove()
         end
 
+        -- Disable all the turrets as soon as player press the button at stealth laser room.
+        -- This will allow player continue to progress even if they failed to stealth.
+        ents.WaitForEntityByName("s_room_off_relay", function(ent)
+            ent:Fire("AddOutput", "OnTrigger s_room_doors,Open,,0,-1")
+            ent:Fire("AddOutput", "OnTrigger s_room_turret_*,Disable,,0,-1")
+        end)
+
         local triggersdoor = ents.Create("trigger_once")
         triggersdoor:SetupTrigger(Vector(3235, -1504, 592), Angle(0, 0, 0), Vector(-200, -65, -80), Vector(200, 65, 80))
         triggersdoor:SetKeyValue("teamwait", "1")
@@ -105,19 +112,6 @@ function MAPSCRIPT:PostInit()
                 ent:Fire("Trigger")
             end)
         end
-
-        -- If player failed to stealth, but success press the button, then disable all turrets and open the door.
-        ents.WaitForEntityByName("s_room_off_relay", function(ent)
-            ent:Fire("AddOutput", "OnTrigger s_room_turret_1,Disable,,0,-1")
-            ent:Fire("AddOutput", "OnTrigger s_room_turret_2,Disable,,0,-1")
-            ent:Fire("AddOutput", "OnTrigger s_room_turret_3,Disable,,0,-1")
-            ent:Fire("AddOutput", "OnTrigger s_room_turret_4,Disable,,0,-1")
-            ent:Fire("AddOutput", "OnTrigger s_room_turret_5,Disable,,0,-1")
-            ent:Fire("AddOutput", "OnTrigger s_room_turret_6,Disable,,0,-1")
-            ent:Fire("AddOutput", "OnTrigger s_room_turret_7,Disable,,0,-1")
-            ent:Fire("AddOutput", "OnTrigger s_room_turret_8,Disable,,0,-1")
-            ent:Fire("AddOutput", "OnTrigger s_room_doors,Open,,0,-1")
-        end)
 
         local checkpoint3 = GAMEMODE:CreateCheckpoint(Vector(2405, 865, 260), Angle(0, 0, 0))
         local checkpointTrigger3 = ents.Create("trigger_once")

--- a/gamemode/gametypes/hl2/mapscripts/d3_c17_10b.lua
+++ b/gamemode/gametypes/hl2/mapscripts/d3_c17_10b.lua
@@ -24,7 +24,8 @@ MAPSCRIPT.DefaultLoadout = {
 }
 
 MAPSCRIPT.InputFilters = {
-    ["s_room_panelswitch"] = {"Lock"} -- Prevent it from locking the button.
+    ["s_room_panelswitch"] = {"Lock"}, -- Prevent it from locking the button.
+    ["n_room_camera_2"] = {"Toggle"}
 }
 
 MAPSCRIPT.EntityFilterByClass = {}

--- a/gamemode/gametypes/hl2/mapscripts/d3_c17_10b.lua
+++ b/gamemode/gametypes/hl2/mapscripts/d3_c17_10b.lua
@@ -59,28 +59,64 @@ function MAPSCRIPT:PostInit()
             ent:Fire("AddOutput", "OnCompletion npc_citizen,SetSquad,player_squad,7,-1")
         end)
 
-        -- Add another logic relay that disables all turrets once the button is pressed.
-        local turretsOffRelay = ents.Create("logic_relay")
-        turretsOffRelay:SetKeyValue("targetname", "s_room_off_relay")
-        turretsOffRelay:SetKeyValue("StartDisabled", "0")
-        turretsOffRelay:SetKeyValue("OnTrigger", "s_room_turret_1,Disable,,0,-1")
-        turretsOffRelay:SetKeyValue("OnTrigger", "s_room_turret_2,Disable,,0,-1")
-        turretsOffRelay:SetKeyValue("OnTrigger", "s_room_turret_3,Disable,,0,-1")
-        turretsOffRelay:SetKeyValue("OnTrigger", "s_room_turret_4,Disable,,0,-1")
-        turretsOffRelay:SetKeyValue("OnTrigger", "s_room_turret_5,Disable,,0,-1")
-        turretsOffRelay:SetKeyValue("OnTrigger", "s_room_turret_6,Disable,,0,-1")
-        turretsOffRelay:SetKeyValue("OnTrigger", "s_room_turret_7,Disable,,0,-1")
-        turretsOffRelay:SetKeyValue("OnTrigger", "s_room_turret_8,Disable,,0,-1")
-        turretsOffRelay:SetKeyValue("OnTrigger", "s_room_doors,Open,,0,-1")
-        turretsOffRelay:Spawn()
-        -- 2657.141357 1033.785645 256.031250
-        local checkpoint2 = GAMEMODE:CreateCheckpoint(Vector(2657.141357, 1033.785645, 256.031250), Angle(0, 0, 0))
-        local checkpointTrigger2 = ents.Create("trigger_once")
-        checkpointTrigger2:SetupTrigger(Vector(2657.141357, 1033.785645, 256.031250), Angle(0, 0, 0), Vector(-60, -60, 0), Vector(60, 60, 100))
+        ents.WaitForEntityByName("lcs_barney_h4x", function(ent)
+            ent:Fire("AddOutput", "OnCompletion s_room_doors,Close,,10,-1")
+            ent:Fire("AddOutput", "OnCompletion n_room_trapdoor_1a,Close,,10,-1")
+            ent:Fire("AddOutput", "OnCompletion n_room_trapdoor_1b,Close,,10,-1")
+            ent:Fire("AddOutput", "OnCompletion n_room_camera_2,Disable,,10,-1")
+        end)
 
-        checkpointTrigger2.OnTrigger = function(_, activator)
-            GAMEMODE:SetPlayerCheckpoint(checkpoint2, activator)
+        for _, v in ipairs(ents.FindByModel("*147")) do
+            v:Remove()
         end
+
+        local triggersdoor = ents.Create("trigger_once")
+        triggersdoor:SetupTrigger(Vector(3235, -1504, 592), Angle(0, 0, 0), Vector(-200, -65, -80), Vector(200, 65, 80))
+        triggersdoor:SetKeyValue("teamwait", "1")
+
+        triggersdoor.OnTrigger = function(ent)
+            GAMEMODE:FilterEntityInput("s_room_doors", "Close")
+
+            TriggerOutputs({{"barney_laseroom_lcs", "Start", 0.5, ""}})
+            for _, v in pairs(ents.FindByPos(Vector(3168, -1564, 576), "func_door")) do
+                v:Fire("Open")
+            end
+        end
+
+        ents.WaitForEntityByName("n_room_trigger_relay", function(ent)
+            ent:Fire("AddOutput", "OnTrigger n_room_doors2_close_relay,Trigger,,0,-1")
+        end)
+
+        ents.WaitForEntityByName("n_room_trigger_1", function(ent)
+            ent:Remove()
+        end)
+
+        local checkpoint2 = GAMEMODE:CreateCheckpoint(Vector(3175, 1155, 530), Angle(0, 0, 0))
+
+        local triggernroom = ents.Create("trigger_once")
+        triggernroom:SetupTrigger(Vector(3072, 900, 552), Angle(0, 0, 0), Vector(-497, -341, -33), Vector(297, 341, 33))
+        triggernroom:SetKeyValue("teamwait", "1")
+
+        triggernroom.OnTrigger = function(_, activator)
+            GAMEMODE:SetPlayerCheckpoint(checkpoint2, activator)
+
+            ents.WaitForEntityByName("n_room_trigger_relay", function(ent)
+                ent:Fire("Trigger")
+            end)
+        end
+
+        -- If player failed to stealth, but success press the button, then disable all turrets and open the door.
+        ents.WaitForEntityByName("s_room_off_relay", function(ent)
+            ent:Fire("AddOutput", "OnTrigger s_room_turret_1,Disable,,0,-1")
+            ent:Fire("AddOutput", "OnTrigger s_room_turret_2,Disable,,0,-1")
+            ent:Fire("AddOutput", "OnTrigger s_room_turret_3,Disable,,0,-1")
+            ent:Fire("AddOutput", "OnTrigger s_room_turret_4,Disable,,0,-1")
+            ent:Fire("AddOutput", "OnTrigger s_room_turret_5,Disable,,0,-1")
+            ent:Fire("AddOutput", "OnTrigger s_room_turret_6,Disable,,0,-1")
+            ent:Fire("AddOutput", "OnTrigger s_room_turret_7,Disable,,0,-1")
+            ent:Fire("AddOutput", "OnTrigger s_room_turret_8,Disable,,0,-1")
+            ent:Fire("AddOutput", "OnTrigger s_room_doors,Open,,0,-1")
+        end)
     end
 end
 

--- a/gamemode/gametypes/hl2/mapscripts/d3_c17_10b.lua
+++ b/gamemode/gametypes/hl2/mapscripts/d3_c17_10b.lua
@@ -117,6 +117,14 @@ function MAPSCRIPT:PostInit()
             ent:Fire("AddOutput", "OnTrigger s_room_turret_8,Disable,,0,-1")
             ent:Fire("AddOutput", "OnTrigger s_room_doors,Open,,0,-1")
         end)
+
+        local checkpoint3 = GAMEMODE:CreateCheckpoint(Vector(2405, 865, 260), Angle(0, 0, 0))
+        local checkpointTrigger3 = ents.Create("trigger_once")
+        checkpointTrigger3:SetupTrigger(Vector(2565, 865, 260), Angle(0, 0, 0), Vector(-10, -70, -80), Vector(10, 70, 80))
+
+        checkpointTrigger3.OnTrigger = function(_, activator)
+            GAMEMODE:SetPlayerCheckpoint(checkpoint3, activator)
+        end
     end
 end
 

--- a/gamemode/gametypes/hl2/mapscripts/d3_c17_10b.lua
+++ b/gamemode/gametypes/hl2/mapscripts/d3_c17_10b.lua
@@ -24,14 +24,14 @@ MAPSCRIPT.DefaultLoadout = {
 }
 
 MAPSCRIPT.InputFilters = {
-    ["s_room_panelswitch"] = {"Lock"}, -- Prevent it from locking the button.
-    ["lobby_combinedoor_portalbrush"] = {"Enable"}
+    ["s_room_panelswitch"] = {"Lock"} -- Prevent it from locking the button.
 }
 
 MAPSCRIPT.EntityFilterByClass = {}
 
 MAPSCRIPT.EntityFilterByName = {
-    ["player_spawn_items"] = true
+    ["player_spawn_items"] = true,
+    ["lobby_combinedoor_portalbrush"] = true
 }
 
 function MAPSCRIPT:PostInit()
@@ -45,8 +45,18 @@ function MAPSCRIPT:PostInit()
             GAMEMODE:SetPlayerCheckpoint(checkpoint1, activator)
         end
 
+        -- Don't close the door once it's opened.
         GAMEMODE:WaitForInput("lobby_combinedoor", "SetAnimation", function()
-            GAMEMODE:FilterEntityInput("lobby_combinedoor", "SetAnimation") -- Don't close the door once it's opened.
+            GAMEMODE:FilterEntityInput("lobby_combinedoor", "SetAnimation")
+        end)
+
+        for _, v in pairs(ents.FindByPos(Vector(2768, 1136, 832), "trigger_once")) do
+            v:ClearOutputs()
+            v:Fire("AddOutput", "OnTrigger roof_soldiersquad_soldier_makers,Disable,,0,-1")
+        end
+
+        ents.WaitForEntityByName("lcs_barney_h4x_pows", function(ent)
+            ent:Fire("AddOutput", "OnCompletion npc_citizen,SetSquad,player_squad,7,-1")
         end)
 
         -- Add another logic relay that disables all turrets once the button is pressed.


### PR DESCRIPTION
Improve(s):
- d3_c17_10b: The fully (I think) of multiplayer support. Now it has checkpoints and you have to wait your teammates to progress the map.

Fix(s):
- d1_canals_07: The metrocop don't use turret which kinda break the scene what Valve want you to see.
- d3_c17_06b: Player can kill the first scripted NPC he seen.
- d3_c17_10b: 2 combine doors in 1st floor can be closed to block players with slow progress.
- d3_c17_10b: Citizens in the jail won't follow player even player rescued them.
- d3_c17_10b: Player failed the stealth mission in laser room and died in there causing softlock.