### PR TITLE
Fixes gravity gun animation doesn't properly works with 'item_item_crate'

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,7 @@
 - Fixed: d1_canals_07: Metrocop didn't use the turret.
 - Fixed: d3_c17_06b: Player can kill a friendly NPC and probability trigger a soft-lock.
 - Fixed: d3_c17_10b: Player died in laser room, make the map unable to proceed.
+- Fixed: Gravity gun animation doesn't properly works when breaking a ammo crate.
 
 0.9.17
 - Improved: Addon compatibility, Lambda will attempt to recover if there are conflicts and warns about it.

--- a/entities/weapons/weapon_physcannon.lua
+++ b/entities/weapons/weapon_physcannon.lua
@@ -1441,12 +1441,12 @@ function SWEP:PuntVPhysics(ent, fwd, tr)
 
         owner:SimulateGravGunPickup(ent, true)
         local phys = ent:GetPhysicsObjectNum(0)
-        if IsValid(phys) ~= true then return end
-
-        if phys:HasGameFlag(FVPHYSICS_CONSTRAINT_STATIC) and ent:IsVehicle() then
-            fwd.x = 0
-            fwd.y = 0
-            fwd.z = 0
+        if IsValid(phys) then
+            if phys:HasGameFlag(FVPHYSICS_CONSTRAINT_STATIC) and ent:IsVehicle() then
+                fwd.x = 0
+                fwd.y = 0
+                fwd.z = 0
+            end
         end
 
         -- if ( !Pickup_ShouldPuntUseLaunchForces( pEntity, PHYSGUN_FORCE_PUNTED ) )


### PR DESCRIPTION
Entity 'item_item_crate' break in primary attack, getting physics object of a not valid entity will fail, resulting animation doesn't run.