### PR TITLE
Fixes player can pickup a dissolving weapon

### DIFF
--- a/gamemode/gametypes/hl2.lua
+++ b/gamemode/gametypes/hl2.lua
@@ -152,6 +152,10 @@ function GAMETYPE:ShouldRestartRound()
 end
 
 function GAMETYPE:PlayerCanPickupWeapon(ply, wep)
+    if wep:IsFlagSet(FL_DISSOLVING) then
+        return false -- Do not let player E pick a dissolving weapon.
+    end
+
     local class = wep:GetClass()
 
     if class == "weapon_frag" then


### PR DESCRIPTION
Player can pickup NPCs weapon in d3_citadel_03 and d3_citadel_04 by pressing E key, see [this video](https://cdn.discordapp.com/attachments/724385668146659386/1133355821070299186/gmod.exe_2023.07.25_-_19.04.53.247_00_00_41-.mp4) for a reproduce.
I don't write to changelog since it's not a "common" issue, it will only seen when player trolling or intentional.