### PR TITLE
Allow Free Roaming observers

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,5 @@
 0.9.26 (in development)
+- Added "Free-Roaming" mode when spectating
 - Improved: Going in and out of the settings no longer clips into the player model.
 - Fixed: NPC makers not respecting the spawn frequency -1 causing a lot of NPCs being spawned in some cases.
 - Fixed: ep1_c17_00a: Don't cancel scripted_sequence on player death.

--- a/gamemode/sh_spectate.lua
+++ b/gamemode/sh_spectate.lua
@@ -40,14 +40,25 @@ if SERVER then
     end
 
     function PLAYER_META:ChangeSpectateMode()
+
+        local mode = self:GetSpectateMode()
         local target = self:GetObserverTarget()
 
-        if self:GetSpectateMode() == 5 then
-            self:SetObserverMode(4)
-            self:SetupHands(target)
-        elseif self:GetSpectateMode() == 4 then
+        -- Third person
+        if mode == 4 then
             self:SetObserverMode(5)
             self:SetupHands(nil)
+
+        -- Free Roaming
+        elseif mode == 5 then
+            self:SetObserverMode(6)
+            self:SetupHands(nil)
+
+        -- First person
+        elseif mode == 6 then
+            self:SetObserverMode(4)
+            self:SetupHands(target)
+
         end
     end
 


### PR DESCRIPTION
When "checkpoint_respawn" is true, it may be really boring to be limited to watch a player, instead allow for a third spectate mode for roaming around the map