### PR TITLE
Fix #332: Weapons respawn at where they were first picked up

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 - Fixed: ep1_c17_00a: Don't cancel scripted_sequence on player death.
 - Fixed: Weapons not properly transitioning for NPCs.
 - Fixed: Entity outputs not firing in the correct order.
+- Fixed: Weapons don't respawn at where they were first picked up.
 
 0.9.25
 - Improved: Hints will no longer show duplicates, instead it will renew the existing hint that has the same text.

--- a/gamemode/sv_player_pickup.lua
+++ b/gamemode/sv_player_pickup.lua
@@ -110,6 +110,9 @@ function GM:RespawnObject(obj, options)
         data.outputs = table.Copy(obj.EntityOutputs or {})
     else
         data = table.Copy(data)
+        -- Override pos and ang, some weapons are moved or thrown at the player.
+        data.pos = obj:GetPos()
+        data.ang = obj:GetAngles()
         data.levelDesignerPlaced = true
         data.options = options
     end


### PR DESCRIPTION
Close #332