### PR TITLE
Replace deprecated "killicon.Draw" to "killicon.Render"

### DIFF
--- a/gamemode/huds/hud_deathnotice.lua
+++ b/gamemode/huds/hud_deathnotice.lua
@@ -251,7 +251,7 @@ local function DrawDeathEntry(bounds, y, data, margin, remaining)
     end
 
     x = x - killiconHalf - killiconOffset
-    killicon.Draw(x, y, data.icon, alpha)
+    killicon.Render(x - killiconHalf, y, data.icon, alpha)
     x = x - killiconHalf - killiconOffset
     x = x - margin
 


### PR DESCRIPTION
[killicon.Draw](https://wiki.facepunch.com/gmod/killicon.Draw) are deprecated, we shouldn't use it anymore.
Does not affect anything (see [official change](https://github.com/Facepunch/garrysmod/commit/29d0f42a189631788fe95f954f9ca639d2386707#diff-ae4a06386b1ee0a686af33604499f5bc831a14b639b9a204dc7e54e638820769L207)).