### PR TITLE
Various improvements to Half-Life 2 map scripts.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,9 @@
 - Fixed: False positive warnings about unhandled onplayerdeath on scripted_sequence.
 - Fixed: Players spawning with the suit if there is no map script, there should be nothing.
 - Added: QuickInfo HUD element (default Half-Life 2 crosshair).
+- Fixed: point_viewcontrol entities on d1_trainstation_01 having incorrect flags set.
+- Fixed: Force field on d2_coast_07 not disabled after coming back from d2_coast_08.
+- Improved: Use new checkpoint structure in mapscripts where possible with better positioning (first 5 chapters).
 
 0.9.28
 - Improved: Better prediction handling for the Gravity Gun, should be more responsive with higher ping now.

--- a/gamemode/gametypes/hl2/mapscripts/d1_canals_01.lua
+++ b/gamemode/gametypes/hl2/mapscripts/d1_canals_01.lua
@@ -28,6 +28,55 @@ MAPSCRIPT.ImportantPlayerNPCNames = {
     ["boxcar_vort"] = true
 }
 
+MAPSCRIPT.Checkpoints = {
+    { -- After equipping pistol
+        Pos = Vector(-704, -7064, 273),
+        Ang = Angle(0, 0, 0),
+        WeaponAdditions = { "weapon_pistol" },
+        Trigger = {
+            Pos = Vector(-704, -7064, 320),
+            Mins = Vector(-64, -64, -64),
+            Maxs = Vector(64, 64, 64)
+        }
+    },
+    { -- After jumping the train and entering house
+        Pos = Vector(619.656433, -6512.142578, 540.031250),
+        Ang = Angle(0, 0, 0),
+        Trigger = {
+            Pos = Vector(614.625732, -6519.078613, 540.031250),
+            Mins = Vector(-100, -100, 0),
+            Maxs = Vector(100, 100, 180)
+        }
+    },
+    { -- Before stairs with those annoying barrels
+        Pos = Vector(473.498352, -3530.257324, 256.031250),
+        Ang = Angle(0, 90, 0),
+        Trigger = {
+            Pos = Vector(544.810791, -3423.548584, 322.719330),
+            Mins = Vector(-70, -70, -50),
+            Maxs = Vector(70, 70, 100)
+        }
+    },
+    { -- Narrow catwalk above tracks
+        Pos = Vector(447.302185, -2656.709961, 576.031250),
+        Ang = Angle(0, 180, 0),
+        Trigger = {
+            Pos = Vector(447.302185, -2656.709961, 576.031250),
+            Mins = Vector(-50, -50, 0),
+            Maxs = Vector(50, 50, 100)
+        }
+    },
+    { -- Boxcar / vort healing
+        Pos = Vector(853.600281, 2638.468018, 73.964828),
+        Ang = Angle(0, 180, 0),
+        Trigger = {
+            Pos = Vector(855.660400, 2638.366943, 30),
+            Mins = Vector(-60, -60, 0),
+            Maxs = Vector(60, 60, 180)
+        }
+    },
+}
+
 function MAPSCRIPT:PostInit()
     if SERVER then
         local jumpBox = ents.Create("prop_physics")
@@ -53,42 +102,7 @@ function MAPSCRIPT:PostInit()
             end)
         end)
 
-        local checkpoint1 = GAMEMODE:CreateCheckpoint(Vector(650.433105, -6424.663086, 540.031250))
-        checkpoint1:SetVisiblePos(Vector(619.656433, -6512.142578, 540.031250))
-        local checkpointTrigger1 = ents.Create("trigger_once")
-        checkpointTrigger1:SetupTrigger(Vector(614.625732, -6519.078613, 540.031250), Angle(0, 0, 0), Vector(-100, -100, 0), Vector(100, 100, 180))
-
-        checkpointTrigger1.OnTrigger = function(_, activator)
-            GAMEMODE:SetPlayerCheckpoint(checkpoint1, activator)
-        end
-
-        -- Boxcar checkpoint
-        local checkpoint2 = GAMEMODE:CreateCheckpoint(Vector(877.780457, 2621.807617, -55.060749), Angle(0, 180, 0))
-        checkpoint2:SetVisiblePos(Vector(853.600281, 2638.468018, 73.964828))
-        local checkpointTrigger2 = ents.Create("trigger_once")
-        checkpointTrigger2:SetupTrigger(Vector(855.660400, 2638.366943, 30), Angle(0, 0, 0), Vector(-100, -100, 0), Vector(100, 100, 180))
-
-        checkpointTrigger2.OnTrigger = function(_, activator)
-            GAMEMODE:SetPlayerCheckpoint(checkpoint2, activator)
-        end
-
-        -- 447.302185 -2656.709961 576.031250
-        local checkpoint3 = GAMEMODE:CreateCheckpoint(Vector(447.302185, -2656.709961, 576.031250), Angle(0, 180, 0))
-        local checkpointTrigger3 = ents.Create("trigger_once")
-        checkpointTrigger3:SetupTrigger(Vector(447.302185, -2656.709961, 576.031250), Angle(0, 0, 0), Vector(-50, -50, 0), Vector(50, 50, 180))
-
-        checkpointTrigger3.OnTrigger = function(_, activator)
-            GAMEMODE:SetPlayerCheckpoint(checkpoint3, activator)
-        end
-
-        -- 544.810791 -3423.548584 322.719330
-        local checkpoint4 = GAMEMODE:CreateCheckpoint(Vector(473.498352, -3530.257324, 256.031250), Angle(0, 90, 0))
-        local checkpointTrigger4 = ents.Create("trigger_once")
-        checkpointTrigger4:SetupTrigger(Vector(544.810791, -3423.548584, 322.719330), Angle(0, 0, 0), Vector(-70, -70, -50), Vector(70, 70, 100))
-
-        checkpointTrigger4.OnTrigger = function(_, activator)
-            GAMEMODE:SetPlayerCheckpoint(checkpoint4, activator)
-        end
+        -- MAYBE TODO: Disable combine shield wall behind the train so players who fell off the train don't get stuck
     end
 end
 

--- a/gamemode/gametypes/hl2/mapscripts/d1_canals_01a.lua
+++ b/gamemode/gametypes/hl2/mapscripts/d1_canals_01a.lua
@@ -22,32 +22,38 @@ MAPSCRIPT.EntityFilterByName = {
     ["spawnitems_template"] = true
 }
 
+MAPSCRIPT.Checkpoints = {
+    { -- Sewer tunnel before ladder to machine gun
+        Pos = Vector(2104.908447, 5759.881348, -95.968750),
+        Ang = Angle(0, 45, 0),
+        Trigger = {
+            Pos = Vector(2104.908447, 5759.881348, -95.968750),
+            Mins = Vector(-100, -100, 0),
+            Maxs = Vector(100, 100, 180)
+        }
+    },
+    { -- Before sewer tunnel with barrels
+        Pos = Vector(-1183.380615, 6344.419922, -59.326172),
+        Ang = Angle(0, -180, 0),
+        Trigger = {
+            Pos = Vector(-1183.380615, 6344.419922, 6.326172),
+            Mins = Vector(-100, -100, -100),
+            Maxs = Vector(100, 100, 100)
+        }
+    },
+    { -- Barnacle slippery slope
+        Pos = Vector(-3002.406494, 7890.711426, 0),
+        Ang = Angle(0, 90, 0),
+        Trigger = {
+            Pos = Vector(-3002.406494, 7870.711426, 48.031250),
+            Mins = Vector(-100, -100, -100),
+            Maxs = Vector(100, 100, 100)
+        }
+    }
+}
+
 function MAPSCRIPT:PostInit()
     if SERVER then
-        local checkpoint1 = GAMEMODE:CreateCheckpoint(Vector(-1183.380615, 6344.419922, -59.326172), Angle(0, -180, 0))
-        local checkpointTrigger1 = ents.Create("trigger_once")
-        checkpointTrigger1:SetupTrigger(Vector(-1183.380615, 6344.419922, 6.326172), Angle(0, 0, 0), Vector(-100, -100, 0), Vector(100, 100, 180))
-
-        checkpointTrigger1.OnTrigger = function(_, activator)
-            GAMEMODE:SetPlayerCheckpoint(checkpoint1, activator)
-        end
-
-        local checkpoint2 = GAMEMODE:CreateCheckpoint(Vector(-3002.406494, 7870.711426, 12.031250), Angle(0, 90, 0))
-        local checkpointTrigger2 = ents.Create("trigger_once")
-        checkpointTrigger2:SetupTrigger(Vector(-3002.406494, 7870.711426, 48.031250), Angle(0, 0, 0), Vector(-100, -100, 0), Vector(100, 100, 180))
-
-        checkpointTrigger2.OnTrigger = function(_, activator)
-            GAMEMODE:SetPlayerCheckpoint(checkpoint2, activator)
-        end
-
-        local checkpoint3 = GAMEMODE:CreateCheckpoint(Vector(2104.908447, 5759.881348, -95.968750), Angle(0, 45, 0))
-        local checkpointTrigger3 = ents.Create("trigger_once")
-        checkpointTrigger3:SetupTrigger(Vector(2104.908447, 5759.881348, -95.968750), Angle(0, 0, 0), Vector(-100, -100, 0), Vector(100, 100, 180))
-
-        checkpointTrigger3.OnTrigger = function(_, activator)
-            GAMEMODE:SetPlayerCheckpoint(checkpoint3, activator)
-        end
-
         local npcMaker1 = ents.Create("npc_maker")
         npcMaker1:SetPos(Vector(-2174.593262, 9086.971680, 288.031250))
         npcMaker1:SetAngles(Angle(0, 180, 0))

--- a/gamemode/gametypes/hl2/mapscripts/d1_canals_02.lua
+++ b/gamemode/gametypes/hl2/mapscripts/d1_canals_02.lua
@@ -24,6 +24,18 @@ MAPSCRIPT.EntityFilterByName = {
     ["global_newgame_spawner_pistol"] = true
 }
 
+MAPSCRIPT.Checkpoints = {
+    { -- Narrow dark tunnels between helicopter attack
+        Pos = Vector(-114.632774, -1179.170288, -847.968750),
+        Ang = Angle(0, 90, 0),
+        Trigger = {
+            Pos = Vector(-114.632774, -1179.170288, -847.968750),
+            Mins = Vector(-100, -100, 0),
+            Maxs = Vector(100, 100, 180)
+        }
+    }
+}
+
 function MAPSCRIPT:PostInit()
     if SERVER then
         -- The map has two spawns both with the priority flag, so we gonna wipe them.
@@ -40,14 +52,6 @@ function MAPSCRIPT:PostInit()
 
         spawn.MasterSpawn = true
         ents.RemoveByClass("prop_physics", Vector(367, 70, -846.01397705078)) -- wooden plate shortcut
-        -- -114.632774 -1179.170288 -847.968750
-        local checkpoint1 = GAMEMODE:CreateCheckpoint(Vector(-114.632774, -1179.170288, -847.968750), Angle(0, 90, 0))
-        local checkpointTrigger1 = ents.Create("trigger_once")
-        checkpointTrigger1:SetupTrigger(Vector(-114.632774, -1179.170288, -847.968750), Angle(0, 0, 0), Vector(-100, -100, 0), Vector(100, 100, 180))
-
-        checkpointTrigger1.OnTrigger = function(_, activator)
-            GAMEMODE:SetPlayerCheckpoint(checkpoint1, activator)
-        end
     end
 end
 

--- a/gamemode/gametypes/hl2/mapscripts/d1_canals_03.lua
+++ b/gamemode/gametypes/hl2/mapscripts/d1_canals_03.lua
@@ -25,24 +25,58 @@ MAPSCRIPT.EntityFilterByName = {
     ["global_newgame_template"] = true
 }
 
+MAPSCRIPT.Checkpoints = {
+    { -- End of narrow corridors
+        Pos = Vector(-722.162354, 1341.204834, -831.968750),
+        Ang = Angle(0, 135, 0),
+        Trigger = {
+            Ang = Angle(0, 45, 0),
+            Pos = Vector(-722.162354, 1341.204834, -831.968750),
+            Mins = Vector(-100, -100, 0),
+            Maxs = Vector(100, 100, 180)
+        }
+    },
+    { -- Before the underwater part
+        Pos = Vector(-1584, -800, -1048),
+        Ang = Angle(0, 0, 0),
+        WeaponAdditions = { "weapon_smg1" },
+        Trigger = {
+            Pos = Vector(-1584, -638, -976),
+            Mins = Vector(-96, -32, -64),
+            Maxs = Vector(96, 32, 64)
+        }
+    },
+    { -- After the underwater part
+        Pos = Vector(-1066, -65, -1014),
+        Ang = Angle(0, 0, 0),
+        Trigger = {
+            Pos = Vector(-1141, -64, -968),
+            Mins = Vector(-27, -30, -72),
+            Maxs = Vector(27, 30, 72)
+        }
+    },
+    { -- Before the 2nd underwater part
+        Pos = Vector(-1833.402344, -775.765564, -895.968750),
+        Ang = Angle(0, -110, 0),
+        Trigger = {
+            Pos = Vector(-1808.799927, -958.450073, -895.968750),
+            Mins = Vector(-100, -100, 0),
+            Maxs = Vector(100, 100, 180)
+        }
+    },
+    { -- Before manhack and water puzzle
+        Pos = Vector(-347.239502, -525.000366, -1017.968750),
+        Ang = Angle(0, -180, 0),
+        Trigger = {
+            Pos = Vector(-446.415466, -526.288147, -1017.968750),
+            Mins = Vector(-60, -60, 0),
+            Maxs = Vector(60, 60, 60)
+        }
+    }
+}
+
 function MAPSCRIPT:PostInit()
     if SERVER then
-        local checkpoint1 = GAMEMODE:CreateCheckpoint(Vector(-722.162354, 1341.204834, -831.968750), Angle(0, 135, 0))
-        local checkpointTrigger1 = ents.Create("trigger_once")
-        checkpointTrigger1:SetupTrigger(Vector(-722.162354, 1341.204834, -831.968750), Angle(0, 0, 0), Vector(-100, -100, 0), Vector(100, 100, 180))
-
-        checkpointTrigger1.OnTrigger = function(_, activator)
-            GAMEMODE:SetPlayerCheckpoint(checkpoint1, activator)
-        end
-
-        local checkpoint2 = GAMEMODE:CreateCheckpoint(Vector(-1368.427856, -69.149689, -1023.968750), Angle(0, 0, 0))
-        local checkpointTrigger2 = ents.Create("trigger_once")
-        checkpointTrigger2:SetupTrigger(Vector(-1058.438110, -66.407013, -959.968750), Angle(0, 0, 0), Vector(-100, -100, 0), Vector(100, 100, 180))
-
-        checkpointTrigger2.OnTrigger = function(_, activator)
-            GAMEMODE:SetPlayerCheckpoint(checkpoint2, activator)
-        end
-
         -- Let him stay alive if no one kills him.
         ents.RemoveByClass("trigger_once", Vector(378, 2620, -770))
         local matt
@@ -68,23 +102,6 @@ function MAPSCRIPT:PostInit()
         ents.WaitForEntityByName("underground_script_matt_spawn_mh1", function(ent)
             ent:Fire("AddOutput", "OnAllSpawnedDead logic_matt_survival,Trigger")
         end)
-
-        local checkpoint3 = GAMEMODE:CreateCheckpoint(Vector(-1833.402344, -775.765564, -895.968750), Angle(0, -110, 0))
-        local checkpointTrigger3 = ents.Create("trigger_once")
-        checkpointTrigger3:SetupTrigger(Vector(-1808.799927, -958.450073, -895.968750), Angle(0, 0, 0), Vector(-100, -100, 0), Vector(100, 100, 180))
-
-        checkpointTrigger3.OnTrigger = function(_, activator)
-            GAMEMODE:SetPlayerCheckpoint(checkpoint3, activator)
-        end
-
-        -- -446.415466 -526.288147 -1017.968750
-        local checkpoint4 = GAMEMODE:CreateCheckpoint(Vector(-347.239502, -525.000366, -1017.968750), Angle(0, -180, 0))
-        local checkpointTrigger4 = ents.Create("trigger_once")
-        checkpointTrigger4:SetupTrigger(Vector(-446.415466, -526.288147, -1017.968750), Angle(0, 0, 0), Vector(-60, -60, 0), Vector(60, 60, 60))
-
-        checkpointTrigger4.OnTrigger = function(_, activator)
-            GAMEMODE:SetPlayerCheckpoint(checkpoint4, activator)
-        end
 
         local a = ents.CreateSimple("prop_physics_override", {
             Pos = Vector(-2153.951416, -852.403381, -1028.920410),

--- a/gamemode/gametypes/hl2/mapscripts/d1_canals_05.lua
+++ b/gamemode/gametypes/hl2/mapscripts/d1_canals_05.lua
@@ -21,6 +21,27 @@ MAPSCRIPT.EntityFilterByName = {
     ["relay_rockfall_start"] = true -- Don't do that, its trivial.
 }
 
+MAPSCRIPT.Checkpoints = {
+    { -- At the big ammo crate with citizen
+        Pos = Vector(4240.543945, 3220.031982, -473.430939),
+        Ang = Angle(0, 90, 0),
+        Trigger = {
+            Pos = Vector(4236.846191, 3261.946289, -474.814972),
+            Mins = Vector(-100, -100, 0),
+            Maxs = Vector(100, 100, 180)
+        }
+    },
+    { -- Airboat location
+        Pos = Vector(7352.527344, 1597.768555, -447.968750),
+        Ang = Angle(0, -90, 0),
+        Trigger = {
+            Pos = Vector(6770.862793, 1569.191040, -447.968750),
+            Mins = Vector(-100, -100, 0),
+            Maxs = Vector(100, 100, 180)
+        }
+    }
+}
+
 local function FreezeEntitiesAt(pos, extent)
     local foundEnts = ents.FindInBox(pos - extent, pos + extent)
     for _, v in pairs(foundEnts) do
@@ -33,22 +54,6 @@ end
 
 function MAPSCRIPT:PostInit()
     if SERVER then
-        local checkpoint1 = GAMEMODE:CreateCheckpoint(Vector(4149.820313, 3446.334229, -466.530853), Angle(0, -66, 0))
-        checkpoint1:SetVisiblePos(Vector(4240.543945, 3220.031982, -473.430939))
-        local checkpointTrigger1 = ents.Create("trigger_once")
-        checkpointTrigger1:SetupTrigger(Vector(4236.846191, 3261.946289, -474.814972), Angle(0, 0, 0), Vector(-100, -100, 0), Vector(100, 100, 180))
-        checkpointTrigger1.OnTrigger = function(_, activator)
-            GAMEMODE:SetPlayerCheckpoint(checkpoint1, activator)
-        end
-
-        local checkpoint2 = GAMEMODE:CreateCheckpoint(Vector(7352.527344, 1597.768555, -447.968750), Angle(0, -90, 0))
-        checkpoint2:SetVisiblePos(Vector(6758.199219, 1572.104248, -447.968750))
-        local checkpointTrigger2 = ents.Create("trigger_once")
-        checkpointTrigger2:SetupTrigger(Vector(6770.862793, 1569.191040, -447.968750), Angle(0, 0, 0), Vector(-100, -100, 0), Vector(100, 100, 180))
-        checkpointTrigger2.OnTrigger = function(_, activator)
-            GAMEMODE:SetPlayerCheckpoint(checkpoint2, activator)
-        end
-
         ents.WaitForEntityByName(
             "rotate_guncave_exit_wheel",
             function(ent)

--- a/gamemode/gametypes/hl2/mapscripts/d1_canals_06.lua
+++ b/gamemode/gametypes/hl2/mapscripts/d1_canals_06.lua
@@ -27,19 +27,36 @@ MAPSCRIPT.EntityFilterByName = {
     ["global_newgame_ammo"] = true,
 }
 
-function MAPSCRIPT:PostInit()
-    if SERVER then
-        -- 140.128403 6230.728516 -91.836014
-        local checkpoint1 = GAMEMODE:CreateCheckpoint(Vector(-244.051270, 5727.869141, -237.508698), Angle(0, 90, 0))
-        checkpoint1:SetVisiblePos(Vector(236.710632, 6244.615234, -75.189445))
-        local checkpointTrigger1 = ents.Create("trigger_once")
-        checkpointTrigger1:SetupTrigger(Vector(140.128403, 6230.728516, -91.836014), Angle(0, 0, 0), Vector(-550, -500, -150), Vector(350, 100, 180))
+MAPSCRIPT.Checkpoints = {
+    { -- After airboat jump puzzle
+        Pos = Vector(352, 5984, -141),
+        Ang = Angle(0, 90, 0),
+        Vehicle = {
+            Pos = Vector(-405.258606, 5841.114258, -212.960327),
+            Ang = Angle(0, 0, 0)
+        },
+        Trigger = {
+            Pos = Vector(140.128403, 6230.728516, -91.836014),
+            Mins = Vector(-650, -500, -150),
+            Maxs = Vector(400, 100, 180)
+        }
+    }
+}
 
-        checkpointTrigger1.OnTrigger = function(_, activator)
-            GAMEMODE:SetVehicleCheckpoint(Vector(-405.258606, 5841.114258, -212.960327), Angle(0, 0, 0))
-            GAMEMODE:SetPlayerCheckpoint(checkpoint1, activator)
-        end
-    end
+function MAPSCRIPT:PostInit()
+    -- Leave this here for now if vehicle checkpoint doesnt work
+    --if SERVER then
+        -- 140.128403 6230.728516 -91.836014
+        --local checkpoint1 = GAMEMODE:CreateCheckpoint(Vector(-244.051270, 5727.869141, -237.508698), Angle(0, 90, 0))
+        --checkpoint1:SetVisiblePos(Vector(236.710632, 6244.615234, -75.189445))
+        --local checkpointTrigger1 = ents.Create("trigger_once")
+        --checkpointTrigger1:SetupTrigger(Vector(140.128403, 6230.728516, -91.836014), Angle(0, 0, 0), Vector(-550, -500, -150), Vector(350, 100, 180))
+
+        --checkpointTrigger1.OnTrigger = function(_, activator)
+        --    GAMEMODE:SetVehicleCheckpoint(Vector(-405.258606, 5841.114258, -212.960327), Angle(0, 0, 0))
+        --    GAMEMODE:SetPlayerCheckpoint(checkpoint1, activator)
+        --end
+    --end
 end
 
 function MAPSCRIPT:PostPlayerSpawn(ply)

--- a/gamemode/gametypes/hl2/mapscripts/d1_canals_07.lua
+++ b/gamemode/gametypes/hl2/mapscripts/d1_canals_07.lua
@@ -25,17 +25,50 @@ MAPSCRIPT.EntityFilterByName = {
     ["global_newgame_spawner_smg"] = true,
 }
 
+MAPSCRIPT.Checkpoints = {
+    { -- Before going inside
+        Pos = Vector(11292.084961, 2207.724365, -255.968750),
+        Ang = Angle(0, -90, 0),
+        Vehicle = {
+            Pos = Vector(10367.498047, 1265.902466, -487.621826),
+            Ang = Angle(0, 90, 0)
+        },
+        Trigger = {
+            Pos = Vector(11296.274414, 2074.708008, -255.968750),
+            Mins = Vector(-100, -100, 0),
+            Maxs = Vector(100, 100, 180)
+        }
+    },
+    { -- After opening the gates
+        Pos = Vector(6497, 758, -455),
+        Ang = Angle(0, -180, 0),
+        Vehicle = {
+            Pos = Vector(6434, 932, -464),
+            Ang = Angle(0, 180, 0)
+        },
+        Trigger = {
+            Pos = Vector(6695, 1017, -318),
+            Mins = Vector(-32, -367, -194),
+            Maxs = Vector(32, 367, 194)
+        }
+    },
+    { -- Inbetween APCs under bridge
+        Pos = Vector(-2430, -7882, -948),
+        Ang = Angle(0, 180, 0),
+        Vehicle = {
+            Pos = Vector(-2430, -7882, -948),
+            Ang = Angle(0, 180, 0)
+        },
+        Trigger = {
+            Pos = Vector(-1797, -7677, -880),
+            Mins = Vector(-128, -512, -144),
+            Maxs = Vector(128, 512, 144)
+        }
+    }
+}
+
 function MAPSCRIPT:PostInit()
     if SERVER then
-        local checkpoint1 = GAMEMODE:CreateCheckpoint(Vector(11292.084961, 2207.724365, -255.968750), Angle(0, -90, 0))
-        local checkpointTrigger1 = ents.Create("trigger_once")
-        checkpointTrigger1:SetupTrigger(Vector(11296.274414, 2074.708008, -255.968750), Angle(0, 0, 0), Vector(-100, -100, 0), Vector(100, 100, 180))
-
-        checkpointTrigger1.OnTrigger = function(_, activator)
-            GAMEMODE:SetVehicleCheckpoint(Vector(10367.498047, 1265.902466, -487.621826), Angle(0, 90, 0))
-            GAMEMODE:SetPlayerCheckpoint(checkpoint1, activator)
-        end
-
         -- Tell metrocop use the turret.
         ents.WaitForEntityByName("logic_room7_spawn_functank_cop", function(ent)
             ent:Fire("AddOutput", "OnTrigger turret_1,ForceNPCOff,,0.12,-1")

--- a/gamemode/gametypes/hl2/mapscripts/d1_canals_08.lua
+++ b/gamemode/gametypes/hl2/mapscripts/d1_canals_08.lua
@@ -26,6 +26,24 @@ MAPSCRIPT.EntityFilterByName = {
     ["relay_locks_closegates"] = true -- Dont close the doors if we pass thru the gate
 }
 
+MAPSCRIPT.Checkpoints = {
+    { -- After leaving airboat
+        Pos = Vector(-486.748169, -329.674469, -591.968750),
+        Ang = Angle(0, 90, 0),
+        WeaponAdditions = { "weapon_357" },
+        Vehicle = {
+            Pos = Vector(53.214970, -102.730621, -615.638123),
+            Ang = Angle(0, -180, 0)
+        },
+        Trigger = {
+            Pos = Vector(-480.402649, -58.779499, -575.968750),
+            Mins = Vector(-100, -100, 0),
+            Maxs = Vector(100, 100, 180)
+        }
+    }
+    -- Do we even need a second CP? If then we'd also need a third
+}
+
 function MAPSCRIPT:PostInit()
     if SERVER then
         for _, v in pairs(ents.FindByClass("info_player_start")) do
@@ -36,25 +54,16 @@ function MAPSCRIPT:PostInit()
         playerStart:SetPos(Vector(7504, -11398, -412))
         playerStart:Spawn()
         playerStart.MasterSpawn = true
-        local checkpoint1 = GAMEMODE:CreateCheckpoint(Vector(-486.748169, -329.674469, -591.968750), Angle(0, 90, 0))
-        checkpoint1:SetVisiblePos(Vector(-420.171631, -97.050110, -591.968750))
-        local checkpointTrigger1 = ents.Create("trigger_once")
-        checkpointTrigger1:SetupTrigger(Vector(-480.402649, -58.779499, -575.968750), Angle(0, 0, 0), Vector(-100, -100, 0), Vector(100, 100, 180))
+        -- Leave commented now for position reference
+        -- --841.505310 -1408.689331 -382.968750
+        --local checkpoint2 = GAMEMODE:CreateCheckpoint(Vector(-841.505310, -1408.689331, -382.968750), Angle(0, 90, 0))
+        --local checkpointTrigger2 = ents.Create("trigger_once")
+        --checkpointTrigger2:SetupTrigger(Vector(-841.505310, -1408.689331, -382.968750), Angle(0, 0, 0), Vector(-100, -100, 0), Vector(100, 100, 180))
 
-        checkpointTrigger1.OnTrigger = function(_, activator)
-            GAMEMODE:SetVehicleCheckpoint(Vector(53.214970, -102.730621, -615.638123), Angle(0, -180, 0))
-            GAMEMODE:SetPlayerCheckpoint(checkpoint1, activator)
-        end
-
-        -- -841.505310 -1408.689331 -382.968750
-        local checkpoint2 = GAMEMODE:CreateCheckpoint(Vector(-841.505310, -1408.689331, -382.968750), Angle(0, 90, 0))
-        local checkpointTrigger2 = ents.Create("trigger_once")
-        checkpointTrigger2:SetupTrigger(Vector(-841.505310, -1408.689331, -382.968750), Angle(0, 0, 0), Vector(-100, -100, 0), Vector(100, 100, 180))
-
-        checkpointTrigger2.OnTrigger = function(_, activator)
-            --GAMEMODE:SetVehicleCheckpoint(Vector(53.214970, -102.730621, -615.638123), Angle(0, -180, 0))
-            GAMEMODE:SetPlayerCheckpoint(checkpoint2, activator)
-        end
+        --checkpointTrigger2.OnTrigger = function(_, activator)
+        --    --GAMEMODE:SetVehicleCheckpoint(Vector(53.214970, -102.730621, -615.638123), Angle(0, -180, 0))
+        --    GAMEMODE:SetPlayerCheckpoint(checkpoint2, activator)
+        --end
 
         -- It looks odd when they spawn right infront of one.
         ents.WaitForEntityByName("bunker_copmaker1", function(ent)

--- a/gamemode/gametypes/hl2/mapscripts/d1_canals_09.lua
+++ b/gamemode/gametypes/hl2/mapscripts/d1_canals_09.lua
@@ -9,7 +9,8 @@ MAPSCRIPT.DefaultLoadout = {
     Weapons = {"weapon_lambda_medkit", "weapon_crowbar", "weapon_pistol", "weapon_smg1", "weapon_357"},
     Ammo = {
         ["Pistol"] = 60,
-        ["SMG1"] = 60
+        ["SMG1"] = 60,
+        ["357"] = 6
     },
     Armor = 0,
     HEV = true

--- a/gamemode/gametypes/hl2/mapscripts/d1_canals_10.lua
+++ b/gamemode/gametypes/hl2/mapscripts/d1_canals_10.lua
@@ -28,6 +28,22 @@ MAPSCRIPT.EntityFilterByName = {
     ["global_newgame_spawner_357"] = true,
 }
 
+MAPSCRIPT.Checkpoints = {
+    { -- At the lift
+        Pos = Vector(4246, 9650, -119),
+        Ang = Angle(0, -90, 0),
+        Vehicle = {
+            Pos = Vector(4270.903320, 9841.201172, -124.578499),
+            Ang = Angle(0, -90, 0)
+        },
+        Trigger = {
+            Pos = Vector(5046.067871, 9267.515625, -127.968750),
+            Mins = Vector(-1500, -1000, -300),
+            Maxs = Vector(100, 600, 180)
+        }
+    }
+}
+
 function MAPSCRIPT:PostInit()
     DbgPrint("MAPSCRIPT:PostInit")
 
@@ -41,15 +57,6 @@ function MAPSCRIPT:PostInit()
         playerStart:SetAngles(Angle(0, 100, 0))
         playerStart:Spawn()
         playerStart.MasterSpawn = true
-        local checkpoint1 = GAMEMODE:CreateCheckpoint(Vector(4757.852051, 9866.387695, -111.968750), Angle(0, 180, 0))
-        checkpoint1:SetVisiblePos(Vector(4269.533691, 9236.030273, -127.968750))
-        local checkpointTrigger1 = ents.Create("trigger_once")
-        checkpointTrigger1:SetupTrigger(Vector(5046.067871, 9267.515625, -127.968750), Angle(0, 0, 0), Vector(-1500, -1000, -300), Vector(100, 600, 180))
-
-        checkpointTrigger1.OnTrigger = function(_, activator)
-            GAMEMODE:SetVehicleCheckpoint(Vector(4270.903320, 9841.201172, -124.578499), Angle(0, 180, 0))
-            GAMEMODE:SetPlayerCheckpoint(checkpoint1, activator)
-        end
     end
 end
 

--- a/gamemode/gametypes/hl2/mapscripts/d1_canals_11.lua
+++ b/gamemode/gametypes/hl2/mapscripts/d1_canals_11.lua
@@ -38,6 +38,22 @@ MAPSCRIPT.ImportantPlayerNPCNames = {
     ["npc_cit_briefer"] = true
 }
 
+MAPSCRIPT.Checkpoints = {
+    { -- Airboat gun upgrade
+        Pos = Vector(6457.725586, 4986.333984, -953.968750),
+        Ang = Angle(0, 180, 0),
+        Vehicle = {
+            Pos = Vector(6363.024902, 4874.115234, -967.214539),
+            Ang = Angle(0, 90, 0)
+        },
+        Trigger = {
+            Pos = Vector(6338.301270, 5018.617188, -953.968750),
+            Mins = Vector(-100, -100, 0),
+            Maxs = Vector(100, 100, 180)
+        }
+    }
+}
+
 MAPSCRIPT.VehicleGuns = false
 
 function MAPSCRIPT:PostInit()
@@ -57,14 +73,6 @@ function MAPSCRIPT:PostInit()
         end)
 
         self.VehicleGuns = false
-        local checkpoint1 = GAMEMODE:CreateCheckpoint(Vector(6457.725586, 4986.333984, -953.968750), Angle(0, 180, 0))
-        local checkpointTrigger1 = ents.Create("trigger_once")
-        checkpointTrigger1:SetupTrigger(Vector(6338.301270, 5018.617188, -953.968750), Angle(0, 0, 0), Vector(-100, -100, 0), Vector(100, 100, 180))
-
-        checkpointTrigger1.OnTrigger = function(_, activator)
-            GAMEMODE:SetVehicleCheckpoint(Vector(6363.024902, 4874.115234, -967.214539), Angle(0, 90, 0))
-            GAMEMODE:SetPlayerCheckpoint(checkpoint1, activator)
-        end
 
         GAMEMODE:WaitForInput("global_newgame_spawner_airboat", "Unlock", function(ent)
             self.VehicleGuns = true

--- a/gamemode/gametypes/hl2/mapscripts/d1_canals_12.lua
+++ b/gamemode/gametypes/hl2/mapscripts/d1_canals_12.lua
@@ -27,20 +27,26 @@ MAPSCRIPT.EntityFilterByName = {
     ["global_newgame_spawner_357"] = true,
 }
 
+MAPSCRIPT.Checkpoints = {
+    { -- Before jump
+        Pos = Vector(-961.568787, -1598.274902, 192.031250),
+        Ang = Angle(0, 0, 0),
+        RenderPos = Vector(-496.403473, -2616.393066, 142.600739),
+        Vehicle = {
+            Pos = Vector(-845.746704, -1628.464966, 120.773956),
+            Ang = Angle(0, -180, 0)
+        },
+        Trigger = {
+            Pos = Vector(-520.426453, -2655.423828, 83.702911),
+            Mins = Vector(-500, -200, 0),
+            Maxs = Vector(500, 200, 280)
+        }
+    }
+}
+
 MAPSCRIPT.VehicleGuns = true
 
 function MAPSCRIPT:PostInit()
-    if SERVER then
-        local checkpoint1 = GAMEMODE:CreateCheckpoint(Vector(-961.568787, -1598.274902, 192.031250), Angle(0, 0, 0))
-        checkpoint1:SetVisiblePos(Vector(-496.403473, -2616.393066, 142.600739))
-        local checkpointTrigger1 = ents.Create("trigger_once")
-        checkpointTrigger1:SetupTrigger(Vector(-520.426453, -2655.423828, 83.702911), Angle(0, 0, 0), Vector(-500, -200, 0), Vector(500, 200, 280))
-
-        checkpointTrigger1.OnTrigger = function(_, activator)
-            GAMEMODE:SetVehicleCheckpoint(Vector(-845.746704, -1628.464966, 120.773956), Angle(0, -180, 0))
-            GAMEMODE:SetPlayerCheckpoint(checkpoint1, activator)
-        end
-    end
 end
 
 function MAPSCRIPT:PostPlayerSpawn(ply)

--- a/gamemode/gametypes/hl2/mapscripts/d1_canals_13.lua
+++ b/gamemode/gametypes/hl2/mapscripts/d1_canals_13.lua
@@ -29,22 +29,29 @@ MAPSCRIPT.EntityFilterByName = {
     ["canals_trigger_elitrans"] = true -- Do not changelevel based on the output.
 }
 
+MAPSCRIPT.Checkpoints = {
+    { -- After gate
+        Pos = Vector(3435.695557, 1247.184448, -385.343903),
+        Ang = Angle(0, 90, 0),
+        RenderPos = Vector(3369.119873, 2166.538818, -367.946716),
+        Vehicle = {
+            Pos = Vector(3437.813477, 1579.182251, -455.238220),
+            Ang = Angle(0, -90, 0)
+        },
+        Trigger = {
+            Pos = Vector(3425.643555, 2139.872314, -476.733490),
+            Mins = Vector(-200, -400, 0),
+            Maxs = Vector(200, 400, 280)
+        }
+    }
+}
+
 MAPSCRIPT.VehicleGuns = true
 
 function MAPSCRIPT:PostInit()
     if SERVER then
         -- TODO: Duplicate canals_npc_reservoircopter01 (player / 2) times
         -- TODO: Trigger helicopter OnDeath outputs only if all of them are dead.
-        local checkpoint1 = GAMEMODE:CreateCheckpoint(Vector(3435.695557, 1247.184448, -385.343903), Angle(0, 90, 0))
-        checkpoint1:SetVisiblePos(Vector(3369.119873, 2166.538818, -367.946716))
-        local checkpointTrigger1 = ents.Create("trigger_once")
-        checkpointTrigger1:SetupTrigger(Vector(3425.643555, 2139.872314, -476.733490), Angle(0, 0, 0), Vector(-200, -400, 0), Vector(200, 400, 280))
-
-        --checkpointTrigger1:RemoveEffects(EF_NODRAW)
-        checkpointTrigger1.OnTrigger = function(_, activator)
-            GAMEMODE:SetVehicleCheckpoint(Vector(3437.813477, 1579.182251, -455.238220), Angle(0, -90, 0))
-            GAMEMODE:SetPlayerCheckpoint(checkpoint1, activator)
-        end
 
         -- We gotta place a giant changelevel trigger here, the other one is dangling in the air and uses Input instead of touch.
         -- -1024.000000 -6656.000000 -1262.920044

--- a/gamemode/gametypes/hl2/mapscripts/d1_town_01.lua
+++ b/gamemode/gametypes/hl2/mapscripts/d1_town_01.lua
@@ -23,30 +23,35 @@ MAPSCRIPT.EntityFilterByName = {
     ["player_spawn_template"] = true
 }
 
+MAPSCRIPT.Checkpoints = {
+    {
+        Pos = Vector(2643.776611, -1465.673584, -3839.968750),
+        Ang = Angle(0, 90, 0),
+        RenderPos = Vector(3005.009521, -1394.904053, -3783.968750),
+        Trigger = {
+            Pos = Vector(3007.881836, -1393.500732, -3783.968750),
+            Mins = Vector(-50, -50, 0),
+            Maxs = Vector(50, 50, 70)
+        }
+    },
+    {
+        Pos = Vector(2018.717896, -1513.990112, -3839.968750),
+        Ang = Angle(0, 90, 0),
+        RenderPos = Vector(2029.538086, -1425.406128, -3839.968750),
+        Trigger = {
+            Pos = Vector(2029.538086, -1425.406128, -3839.968750),
+            Mins = Vector(-90, -100, 0),
+            Maxs = Vector(70, 200, 50)
+        }
+    }
+}
+
 function MAPSCRIPT:PostInit()
     if SERVER then
         -- 2849.690674 -1397.864624 -3839.968750
         ents.WaitForEntityByName("null_filter", function(ent)
             ent:Remove()
         end)
-
-        local checkpoint1 = GAMEMODE:CreateCheckpoint(Vector(2643.776611, -1465.673584, -3839.968750), Angle(0, 90, 0))
-        checkpoint1:SetVisiblePos(Vector(3005.009521, -1394.904053, -3783.968750))
-        local checkpointTrigger1 = ents.Create("trigger_once")
-        checkpointTrigger1:SetupTrigger(Vector(3007.881836, -1393.500732, -3783.968750), Angle(0, 0, 0), Vector(-50, -50, 0), Vector(50, 50, 70))
-
-        checkpointTrigger1.OnTrigger = function(_, activator)
-            GAMEMODE:SetPlayerCheckpoint(checkpoint1, activator)
-        end
-
-        local checkpoint2 = GAMEMODE:CreateCheckpoint(Vector(2018.717896, -1513.990112, -3839.968750), Angle(0, 90, 0))
-        checkpoint2:SetVisiblePos(Vector(2029.538086, -1425.406128, -3839.968750))
-        local checkpointTrigger2 = ents.Create("trigger_once")
-        checkpointTrigger2:SetupTrigger(Vector(2029.538086, -1425.406128, -3839.968750), Angle(0, 0, 0), Vector(-90, -100, 0), Vector(70, 200, 50))
-
-        checkpointTrigger2.OnTrigger = function(_, activator)
-            GAMEMODE:SetPlayerCheckpoint(checkpoint2, activator)
-        end
     end
 end
 

--- a/gamemode/gametypes/hl2/mapscripts/d1_town_04.lua
+++ b/gamemode/gametypes/hl2/mapscripts/d1_town_04.lua
@@ -25,17 +25,19 @@ MAPSCRIPT.EntityFilterByName = {
     ["player_spawn_template"] = true
 }
 
-function MAPSCRIPT:PostInit()
-    if SERVER then
-        -- 1915.561768 -19.246124 -5120.762695
-        local checkpoint1 = GAMEMODE:CreateCheckpoint(Vector(1893.508423, 365.617035, -5120.287109), Angle(0, -90, 0))
-        local checkpointTrigger1 = ents.Create("trigger_once")
-        checkpointTrigger1:SetupTrigger(Vector(1915.561768, -19.246124, -5120.762695), Angle(0, 0, 0), Vector(-150, -50, 0), Vector(150, 50, 70))
+MAPSCRIPT.Checkpoints = {
+    {
+        Pos = Vector(1893.508423, 365.617035, -5120.287109),
+        Ang = Angle(0, -90, 0),
+        Trigger = {
+            Pos = Vector(1915.561768, -19.246124, -5120.762695),
+            Mins = Vector(-150, -50, 0),
+            Maxs = Vector(150, 50, 100)
+        }
+    }
+}
 
-        checkpointTrigger1.OnTrigger = function(_, activator)
-            GAMEMODE:SetPlayerCheckpoint(checkpoint1, activator)
-        end
-    end
+function MAPSCRIPT:PostInit()
 end
 
 function MAPSCRIPT:PostPlayerSpawn(ply)

--- a/gamemode/gametypes/hl2/mapscripts/d1_town_05.lua
+++ b/gamemode/gametypes/hl2/mapscripts/d1_town_05.lua
@@ -42,6 +42,28 @@ MAPSCRIPT.ImportantPlayerNPCNames = {
     ["winston"] = true
 }
 
+MAPSCRIPT.Checkpoints = {
+    {
+        Pos = Vector(-6533.443848, 8131.516602, 896.031250),
+        Ang = Angle(0, 0, 0),
+        RenderPos = Vector(-6447.585449, 8024.932129, 896.031250),
+        Trigger = {
+            Pos = Vector(-6381.103027, 8103.064453, 896.031250),
+            Mins = Vector(-100, -300, 0),
+            Maxs = Vector(100, 300, 170)
+        }
+    },
+    {
+        Pos = Vector(-1098.884766, 10457.261719, 896.031250),
+        Ang = Angle(0, -180, 0),
+        Trigger = {
+            Pos = Vector(-1123.785400, 10358.985352, 896.031250),
+            Mins = Vector(-100, -25, 0),
+            Maxs = Vector(100, 25, 170)
+        }
+    }
+}
+
 function MAPSCRIPT:PostInit()
     if SERVER then
         ents.WaitForEntityByName("warehouse_citizen_jacobs", function(ent)
@@ -68,16 +90,6 @@ function MAPSCRIPT:PostInit()
         ents.WaitForEntityByName("warehouse_deadcombine_counter", function(ent)
             ent:SetName("lambda_warehouse_deadcombine_counter")
         end)
-
-        -- -6381.103027 8103.064453 896.031250
-        local checkpoint1 = GAMEMODE:CreateCheckpoint(Vector(-6533.443848, 8131.516602, 896.031250), Angle(0, 0, 0))
-        checkpoint1:SetVisiblePos(Vector(-6447.585449, 8024.932129, 896.031250))
-        local checkpointTrigger1 = ents.Create("trigger_once")
-        checkpointTrigger1:SetupTrigger(Vector(-6381.103027, 8103.064453, 896.031250), Angle(0, 0, 0), Vector(-100, -300, 0), Vector(100, 300, 170))
-
-        checkpointTrigger1.OnTrigger = function(_, activator)
-            GAMEMODE:SetPlayerCheckpoint(checkpoint1, activator)
-        end
 
         -- Make sure to substract on our renamed math_counter.
         ents.WaitForEntityByName("end_reinforcements_trigger", function(ent)
@@ -123,6 +135,7 @@ function MAPSCRIPT:PostInit()
             ent:SetKeyValue("Radius", 328)
         end)
 
+        -- Leave this checkpoint as is since it has special outputs
         --ent:Fire("AddOutput", "OnAllSpawnedDead lambda_warehouse_deadcombine_counter,Add,1")
         -- -3500.986816 7756.634766 896.031250
         local checkpoint2 = GAMEMODE:CreateCheckpoint(Vector(-4065.605957, 7748.239258, 896.032776), Angle(3.366, 19.338, 0.000))
@@ -168,16 +181,6 @@ function MAPSCRIPT:PostInit()
         ents.WaitForEntityByName("warehouse_leonleads_lcs", function(ent)
             ent:Fire("AddOutput", "OnTrigger2 !self,Resume,,2") -- Whoever gets picked as freeman, stop giving a fuck.
         end)
-
-        -- Checkpoint
-        -- -1123.785400 10358.985352 896.031250
-        local checkpoint3 = GAMEMODE:CreateCheckpoint(Vector(-1098.884766, 10457.261719, 896.031250), Angle(0, -180, 0.000))
-        local checkpointTrigger3 = ents.Create("trigger_once")
-        checkpointTrigger3:SetupTrigger(Vector(-1123.785400, 10358.985352, 896.031250), Angle(0, 0, 0), Vector(-100, -25, 0), Vector(100, 25, 170))
-
-        checkpointTrigger3.OnTrigger = function(_, activator)
-            GAMEMODE:SetPlayerCheckpoint(checkpoint3, activator)
-        end
 
         -- Better changelevel trigger.
         local changelevelTrigger = ents.CreateSimple("trigger_changelevel", {

--- a/gamemode/gametypes/hl2/mapscripts/d1_trainstation_01.lua
+++ b/gamemode/gametypes/hl2/mapscripts/d1_trainstation_01.lua
@@ -99,9 +99,10 @@ function MAPSCRIPT:PostInit()
             ent:SetHealth(1000)
         end)
 
-        -- Fix point_viewcontrol, affect all players.
+        -- Fix point_viewcontrol, by setting correct flags.
+        local sf = bit.bor(4, 8, 16, 128)
         for k, v in pairs(ents.FindByClass("point_viewcontrol")) do
-            v:SetKeyValue("spawnflags", "128") -- SF_CAMERA_PLAYER_MULTIPLAYER_ALL
+            v:SetKeyValue("spawnflags", sf)
         end
 
         -- Make the cop go outside the hallway so other players can still pass by.

--- a/gamemode/gametypes/hl2/mapscripts/d1_trainstation_04.lua
+++ b/gamemode/gametypes/hl2/mapscripts/d1_trainstation_04.lua
@@ -28,6 +28,27 @@ MAPSCRIPT.EntityFilterByName = {
     ["lcs_knockout_kickdoor"] = true
 }
 
+MAPSCRIPT.Checkpoints = {
+    { -- Before walking on the edge of roof
+        Pos = Vector(-5132.465332, -3575.130127, 698.892090),
+        Ang = Angle(0, -180, 0),
+        Trigger = {
+            Pos = Vector(-5132.465332, -3575.130127, 698.892090),
+            Mins = Vector(-200, -200, 0),
+            Maxs = Vector(200, 200, 100)
+        }
+    },
+    { -- Just before meeting alyx
+        Pos = Vector(-7204.497070, -3997.591064, 384.031250),
+        Ang = Angle(0, -180, 0),
+        Trigger = {
+            Pos = Vector(-7275.987793, -3983.696533, 384.031250),
+            Mins = Vector(-50, -130, 0),
+            Maxs = Vector(160, 130, 100)
+        }
+    }
+}
+
 --["npc_knockout_cop_upstairs"] = true, -- If players are still up they would see them spawn.
 function MAPSCRIPT:PostInit()
     DbgPrint("PostInit")
@@ -79,14 +100,6 @@ function MAPSCRIPT:PostInit()
             DbgPrint("All players left")
         end
 
-        local checkpoint1 = GAMEMODE:CreateCheckpoint(Vector(-5132.465332, -3575.130127, 698.892090), Angle(0, -180, 0))
-        local checkpointTrigger1 = ents.Create("trigger_once")
-        checkpointTrigger1:SetupTrigger(Vector(-5132.465332, -3575.130127, 698.892090), Angle(0, 0, 0), Vector(-200, -200, 0), Vector(200, 200, 100))
-
-        checkpointTrigger1.OnTrigger = function(_, activator)
-            GAMEMODE:SetPlayerCheckpoint(checkpoint1, activator)
-        end
-
         -- We skip the knockout scene because its not shown anyway.
         ents.WaitForEntityByName("door_knockout_1", function(ent)
             --ent:Fire("Lock")
@@ -135,16 +148,6 @@ function MAPSCRIPT:PostInit()
             DbgPrint("Starting alyx action")
             TriggerOutputs({{"breakable_alyxwindow", "Break", 0.5, ""}, {"template_alyx", "ForceSpawn", 0.2, ""}, {"lcs_alyxgreet00", "Start", 0.4, ""}, {"logic_kill_cops", "Trigger", 0.2, ""}, {"relay_knockout_alyxrescue", "Trigger", 0.5, ""}, {"door_knockout_1", "Unlock", 8.5, ""}, {"door_knockout_1", "Open", 8.5, ""}, {"alyx_pos_fix", "Trigger", 8.5, ""}, {"door_knockout_2", "Lock", 1.0, ""}, {"door_knockout_2", "Close", 1.1, ""}, {"global_gordon_invulnerable", "TurnOff", 0.3, ""}, {"relationship_cops_hate_player", "RevertRelationship", 0, ""}, {"sound_knockout_copspeech_done", "PlaySound", 2.0, ""}, {"npc_knockout_cop_upstairs", "Kill", 3.0, ""}, {"mic_alyx", "Enable", 0, ""}}) --{"logic_fade_view", "Trigger", 0.1, ""},
         end)
-
-        -- -7176.394043 -3890.482178 384.031250
-        local checkpoint3 = GAMEMODE:CreateCheckpoint(Vector(-7204.497070, -3997.591064, 384.031250), Angle(0, -180, 0))
-        checkpoint3:SetVisiblePos(Vector(-7275.987793, -3983.696533, 384.031250))
-        local checkpointTrigger3 = ents.Create("trigger_once")
-        checkpointTrigger3:SetupTrigger(Vector(-7275.987793, -3983.696533, 384.031250), Angle(0, 0, 0), Vector(-50, -130, 0), Vector(160, 130, 100))
-
-        checkpointTrigger3.OnTrigger = function(trigger)
-            GAMEMODE:SetPlayerCheckpoint(checkpoint3)
-        end
     end
 end
 

--- a/gamemode/gametypes/hl2/mapscripts/d1_trainstation_05.lua
+++ b/gamemode/gametypes/hl2/mapscripts/d1_trainstation_05.lua
@@ -23,6 +23,27 @@ MAPSCRIPT.ImportantPlayerNPCNames = {
     ["lamarr_jumper"] = true -- In any case this should restart.
 }
 
+MAPSCRIPT.Checkpoints = {
+    { -- Entering kleiner's lab
+        Pos = Vector(-6569.488281, -1150.120850, 0.031250),
+        Ang = Angle(0, 0, 0),
+        Trigger = {
+            Pos = Vector(-6482.711914, -1095.658813, 0.031250),
+            Mins = Vector(-50, -50, 0),
+            Maxs = Vector(50, 50, 180)
+        }
+    },
+    { -- Outside after tp scene
+        Pos = Vector(-10368, -4714, 320),
+        Ang = Angle(0, 180, 0),
+        Trigger = {
+            Pos = Vector(-10368, -4714, 320),
+            Mins = Vector(-50, -50, 0),
+            Maxs = Vector(50, 50, 180)
+        }
+    }
+}
+
 function MAPSCRIPT:PostInit()
     if SERVER then
         self.DefaultLoadout.HEV = false
@@ -70,15 +91,6 @@ function MAPSCRIPT:PostInit()
         doorTrigger.OnTrigger = function()
             allowPlayerClip = true
             TriggerOutputs({{"brush_soda_clip_player", "Enable", 0.0, ""}, {"BarneyEnter_song", "PlaySound", 0.0, ""}, {"speaker_alyxsoda_nags", "Kill", 0.0, ""}, {"lab01_lcs", "Start", 0.1, ""}, {"kleiner_prepose_idle_1", "BeginSequence", 0.3, ""}})
-        end
-
-        -- -6569.488281 -1150.120850 0.031250
-        local checkpoint1 = GAMEMODE:CreateCheckpoint(Vector(-6569.488281, -1150.120850, 0.031250), Angle(0, 0, 0))
-        local checkpointTrigger1 = ents.Create("trigger_once")
-        checkpointTrigger1:SetupTrigger(Vector(-6482.711914, -1095.658813, 0.031250), Angle(0, 0, 0), Vector(-50, -50, 0), Vector(50, 50, 180))
-
-        checkpointTrigger1.OnTrigger = function(_, activator)
-            GAMEMODE:SetPlayerCheckpoint(checkpoint1, activator)
         end
 
         ents.WaitForEntityByName("gman_fixtie_1", function(ent)
@@ -141,15 +153,6 @@ function MAPSCRIPT:PostInit()
             local cp = GAMEMODE:CreateCheckpoint(Vector(-7154, -1508.3, 1), Angle(0, 90, 0))
             GAMEMODE:SetPlayerCheckpoint(cp, nil)
         end)
-
-        -- Outdoor
-        local checkpoint2 = GAMEMODE:CreateCheckpoint(Vector(-10368, -4714, 320), Angle(0, 180, 0))
-        local checkpointTrigger2 = ents.Create("trigger_once")
-        checkpointTrigger2:SetupTrigger(Vector(-10368, -4714, 320), Angle(0, 0, 0), Vector(-50, -50, 0), Vector(50, 50, 180))
-
-        checkpointTrigger2.OnTrigger = function(_, activator)
-            GAMEMODE:SetPlayerCheckpoint(checkpoint2, activator)
-        end
 
         -- Reposition alyx intro position a bit
         ents.WaitForEntityByName("mark_alyx_intro", function(ent)

--- a/gamemode/gametypes/hl2/mapscripts/d2_coast_04.lua
+++ b/gamemode/gametypes/hl2/mapscripts/d2_coast_04.lua
@@ -36,6 +36,51 @@ MAPSCRIPT.EntityFilterByName = {
     ["crane_soldier_kill"] = true -- Why?
 }
 
+MAPSCRIPT.Checkpoints = {
+    { -- rush / off pier checkpoint
+        Pos = Vector(1864.473999, -3026.903076, 256.031250),
+        Ang = Angle(0, 90, 0),
+        RenderPos = Vector(2385.852539, -2325.066406, 256.031250),
+        Vehicle = {
+            Pos = Vector(3377.796875, -1352.083008, 9.863693),
+            Ang = Angle(0, 0, 0)
+        },
+        Trigger = {
+            Pos = Vector(2385.852539, -2325.066406, 256.031250),
+            Mins = Vector(-100, -100, 0),
+            Maxs = Vector(100, 100, 180)
+        }
+    },
+    { -- bridge checkpoint
+        Pos = Vector(5189.114258, -2913.917236, 384.031250),
+        Ang = Angle(0, 90, 0),
+        RenderPos = Vector(5037.148438, -2688.796875, 384.031250),
+        Vehicle = {
+            Pos = Vector(5128.125488, -2679.885986, 384.031250),
+            Ang = Angle(0, -90, 0)
+        },
+        Trigger = {
+            Pos = Vector(5068.378418, -2688.673828, 384.031250),
+            Mins = Vector(-100, -100, 0),
+            Maxs = Vector(100, 100, 180)
+        }
+    },
+    { -- fall checkpoint
+        Pos = Vector(-1328.088135, -1649.725464, 958.014343),
+        Ang = Angle(0, 90, 0),
+        RenderPos = Vector(-1826.550537, -1218.092041, 928.031250),
+        Vehicle = {
+            Pos = Vector(-1352.137207, -1540.197876, 951.312805),
+            Ang = Angle(0, 90, 0)
+        },
+        Trigger = {
+            Pos = Vector(-1823.722290, -1220.703369, 928.031250),
+            Mins = Vector(-200, -100, 0),
+            Maxs = Vector(200, 100, 180)
+        }
+    },
+}
+
 MAPSCRIPT.VehicleGuns = true
 
 function MAPSCRIPT:PostInit()
@@ -79,30 +124,6 @@ function MAPSCRIPT:PostInit()
                 ent:Fire("Enable")
             end)
         end)
-
-        -- rush checkpoint
-        -- 2835.472412 -1599.243896 142.031235, 1864.473999 -3026.903076 256.031250
-        local checkpoint1 = GAMEMODE:CreateCheckpoint(Vector(1864.473999, -3026.903076, 256.031250), Angle(0, 90, 0))
-        checkpoint1:SetVisiblePos(Vector(2385.852539, -2325.066406, 256.031250))
-        local checkpointTrigger1 = ents.Create("trigger_once")
-        checkpointTrigger1:SetupTrigger(Vector(2385.852539, -2325.066406, 256.031250), Angle(0, 0, 0), Vector(-100, -100, 0), Vector(100, 100, 180))
-
-        checkpointTrigger1.OnTrigger = function(_, activator)
-            GAMEMODE:SetVehicleCheckpoint(Vector(3377.796875, -1352.083008, 9.863693), Angle(0, 0, 0))
-            GAMEMODE:SetPlayerCheckpoint(checkpoint1, activator)
-        end
-
-        -- bridge checkpoint
-        -- 5068.378418 -2688.673828 384.031250
-        local checkpoint2 = GAMEMODE:CreateCheckpoint(Vector(5189.114258, -2913.917236, 384.031250), Angle(0, 90, 0))
-        checkpoint2:SetVisiblePos(Vector(5037.148438, -2688.796875, 384.031250))
-        local checkpointTrigger2 = ents.Create("trigger_once")
-        checkpointTrigger2:SetupTrigger(Vector(5068.378418, -2688.673828, 384.031250), Angle(0, 0, 0), Vector(-100, -100, 0), Vector(100, 100, 180))
-
-        checkpointTrigger2.OnTrigger = function(_, activator)
-            GAMEMODE:SetVehicleCheckpoint(Vector(5128.125488, -2679.885986, 384.031250), Angle(0, -90, 0))
-            GAMEMODE:SetPlayerCheckpoint(checkpoint2, activator)
-        end
 
         -- More enemies inside the warehouse
         local npc
@@ -149,18 +170,6 @@ function MAPSCRIPT:PostInit()
             elseif activator:IsPlayer() and activator:Alive() then
                 activator:Kill()
             end
-        end
-
-        -- fall checkpoint
-        -- 1826.217529 2.297394 928.031250
-        local checkpoint3 = GAMEMODE:CreateCheckpoint(Vector(-1328.088135, -1649.725464, 958.014343), Angle(0, 90, 0))
-        checkpoint3:SetVisiblePos(Vector(-1826.550537, -1218.092041, 928.031250))
-        local checkpointTrigger3 = ents.Create("trigger_once")
-        checkpointTrigger3:SetupTrigger(Vector(-1823.722290, -1220.703369, 928.031250), Angle(0, 0, 0), Vector(-200, -100, 0), Vector(200, 100, 180))
-
-        checkpointTrigger3.OnTrigger = function(_, activator)
-            GAMEMODE:SetVehicleCheckpoint(Vector(-1352.137207, -1540.197876, 951.312805), Angle(0, 90, 0))
-            GAMEMODE:SetPlayerCheckpoint(checkpoint3, activator)
         end
     end
 end

--- a/gamemode/gametypes/hl2/mapscripts/d2_coast_07.lua
+++ b/gamemode/gametypes/hl2/mapscripts/d2_coast_07.lua
@@ -41,6 +41,9 @@ function MAPSCRIPT:PostInit()
             GAMEMODE:SetPlayerCheckpoint(checkpointTransfer)
             GAMEMODE:SetVehicleCheckpoint(Vector(1227.954468, 6228.015137, 1531.526611), Angle(0, -90, 0))
 
+            -- Add weapon_crossbow to our loadout since we got it on coast_08
+            table.insert(self.DefaultLoadout.Weapons, "weapon_crossbow")
+
             -- Not sure how this worked before and why did it break
             -- That button at the other side of the bridge in coast_08 sets a global state
             -- It also tries to fire these outputs, unsuccessfully

--- a/gamemode/gametypes/hl2/mapscripts/d2_coast_07.lua
+++ b/gamemode/gametypes/hl2/mapscripts/d2_coast_07.lua
@@ -2,6 +2,7 @@ if SERVER then
     AddCSLuaFile()
 end
 
+local DbgPrint = GetLogging("MapScript")
 local MAPSCRIPT = {}
 MAPSCRIPT.PlayersLocked = false
 
@@ -39,6 +40,32 @@ function MAPSCRIPT:PostInit()
             local checkpointTransfer = GAMEMODE:CreateCheckpoint(Vector(3304.103271, 5262.621094, 1536.031250), Angle(0, 90, 0))
             GAMEMODE:SetPlayerCheckpoint(checkpointTransfer)
             GAMEMODE:SetVehicleCheckpoint(Vector(1227.954468, 6228.015137, 1531.526611), Angle(0, -90, 0))
+
+            -- Not sure how this worked before and why did it break
+            -- That button at the other side of the bridge in coast_08 sets a global state
+            -- It also tries to fire these outputs, unsuccessfully
+            -- gunship_trigger_10 disappears on transition back to 07 so it's best to trigger it when spawned
+            if game.GetGlobalState("bridge_gate_open") == GLOBAL_ON then
+                DbgPrint("Global state bridge_gate_open is ON")
+                local returned = ents.Create("trigger_once")
+                returned:SetupTrigger(Vector(3306, 5280, 1592), Angle(0, 0, 0), Vector(-242, -96, -55), Vector(242, 96, 55))
+                -- Outputs from gunship_trigger_10 
+                returned:Fire("AddOutput", "OnTrigger antspawner,Enable,,0,1")
+                returned:Fire("AddOutput", "OnTrigger bridge_field_02,Disable,,0,1")
+                returned:Fire("AddOutput", "OnTrigger gate_sprite,color,0 255 0,0,1")
+                returned:Fire("AddOutput", "OnTrigger field_wall_poles,skin,1,0,1")
+                returned:Fire("AddOutput", "OnTrigger field_trigger,Disable,,0,-1")
+                returned:Fire("AddOutput", "OnTrigger forcefield3_sound_far,StopSound,,0,-1")
+                returned:Fire("AddOutput", "OnTrigger return_cliff_fight_spawn,ForceSpawn,,0,1")
+                returned:Fire("AddOutput", "OnTrigger zombie_blocker,Disable,,0,-1")
+                returned:Fire("AddOutput", "OnTrigger forcefield3_sound_far,Kill,,0.1,-1")
+                returned:Fire("AddOutput", "OnTrigger forcefield3_sound_close,Kill,,0.1,-1")
+                -- Remove dropship and some assault triggers
+                returned:Fire("AddOutput", "OnTrigger dropship,Kill,,0,-1")
+                returned:Fire("AddOutput", "OnTrigger el_gimp,Kill,,0,-1")
+                returned:Fire("AddOutput", "OnTrigger halt_guy,Kill,,0,-1")
+                returned:Fire("AddOutput", "OnTrigger assault_trigger,Kill,,0,-1")
+            end
 
             ents.WaitForEntityByName("village_squad", function(ent)
                 ent:Fire("ForceSpawn")

--- a/gamemode/gametypes/hl2/mapscripts/d2_coast_08.lua
+++ b/gamemode/gametypes/hl2/mapscripts/d2_coast_08.lua
@@ -2,6 +2,7 @@ if SERVER then
     AddCSLuaFile()
 end
 
+local DbgPrint = GetLogging("MapScript")
 local MAPSCRIPT = {}
 MAPSCRIPT.PlayersLocked = false
 
@@ -33,6 +34,7 @@ MAPSCRIPT.VehicleGuns = true
 function MAPSCRIPT:PostInit()
     if SERVER then
         ents.RemoveByClass("info_player_start")
+        local crossbow_added = false
 
         local newPlayerSpawn = ents.Create("info_player_start")
         newPlayerSpawn:SetPos(Vector(3328.9, 5241.59, 1536.1))
@@ -49,9 +51,17 @@ function MAPSCRIPT:PostInit()
             Vector(-250, -60, 0),
             Vector(250, 60, 580)
         )
+
         cp1Trigger.OnTrigger = function(_, activator)
             cp1Trigger:Input("Disable")
             GAMEMODE:SetPlayerCheckpoint(cp1, activator)
+            -- Add crossbow to loadout
+            if crossbow_added == false then
+                local loadout = GAMEMODE:GetMapScript().DefaultLoadout
+                table.insert(loadout.Weapons, "weapon_crossbow")
+                crossbow_added = true
+                DbgPrint("Added crossbow to loadout")
+            end
         end
 
         local cp2 = GAMEMODE:CreateCheckpoint(Vector(3257, -2004, 1551.6), Angle(0, -90, 0))
@@ -75,6 +85,7 @@ function MAPSCRIPT:PostInit()
             Vector(-70, -70, 0),
             Vector(70, 70, 80)
         )
+
         cp4Trigger:KeyValue("StartDisabled", "1")
         cp4Trigger.OnTrigger = function(_, activator)
             GAMEMODE:SetPlayerCheckpoint(cp4, activator)
@@ -95,6 +106,7 @@ function MAPSCRIPT:PostInit()
             Vector(-30, -30, 0),
             Vector(230, 30, 80)
         )
+
         cp3Trigger.OnTrigger = function(_, activator)
             GAMEMODE:SetPlayerCheckpoint(cp3, activator)
             if IsValid(cp4Trigger) then

--- a/gamemode/gametypes/hl2/mapscripts/d2_coast_09.lua
+++ b/gamemode/gametypes/hl2/mapscripts/d2_coast_09.lua
@@ -25,6 +25,10 @@ MAPSCRIPT.DefaultLoadout = {
 MAPSCRIPT.InputFilters = {}
 MAPSCRIPT.EntityFilterByClass = {}
 
+MAPSCRIPT.GlobalStates = {
+    ["bridge_gate_open"] = GLOBAL_OFF
+}
+
 MAPSCRIPT.EntityFilterByName = {
     ["global_newgame_spawner_ammo"] = true,
     ["global_newgame_template_local_items"] = true,

--- a/gamemode/gametypes/hl2/mapscripts/d2_coast_09.lua
+++ b/gamemode/gametypes/hl2/mapscripts/d2_coast_09.lua
@@ -34,6 +34,36 @@ MAPSCRIPT.EntityFilterByName = {
     ["global_newgame_spawner_physcannon"] = true,
 }
 
+MAPSCRIPT.Checkpoints = {
+    { -- tunnel exit
+        Pos = Vector(-6203.434570, 4812.755859, 512.031250),
+        Ang = Angle(0, -90, 0),
+        RenderPos = Vector(-6399.345703, 4662.560059, 512.031250),
+        Vehicle = {
+            Pos = Vector(-6321.518555, 4750.143066, 532.837036),
+            Ang = Angle(0, 180, 0)
+        },
+        Trigger = {
+            Pos = Vector(-6397.890625, 4632.765625, 512.031250),
+            Mins = Vector(-300, -20, 0),
+            Maxs = Vector(300, 20, 200)
+        }
+    },
+    { -- before outpost
+        Pos = Vector(8648.458008, 11745.508789, -196.678345),
+        Ang = Angle(0, -50, 0),
+        Vehicle = {
+            Pos = Vector(8699.614258, 11645.158203, -192.527618),
+            Ang = Angle(0, -90, 0)
+        },
+        Trigger = {
+            Pos = Vector(8663.506836, 11871.029297, -191.968750),
+            Mins = Vector(-50, -600, 0),
+            Maxs = Vector(50, 450, 200)
+        }
+    }
+}
+
 MAPSCRIPT.VehicleGuns = true
 
 function MAPSCRIPT:PostInit()
@@ -100,25 +130,6 @@ function MAPSCRIPT:PostInit()
         ents.WaitForEntityByName("battery2", ProtectBattery)
         ents.WaitForEntityByName("battery3", ProtectBattery)
         ents.WaitForEntityByName("battery4", ProtectBattery)
-        local checkpoint1 = GAMEMODE:CreateCheckpoint(Vector(-6203.434570, 4812.755859, 512.031250), Angle(0, -90, 0))
-        checkpoint1:SetVisiblePos(Vector(-6399.345703, 4662.560059, 512.031250))
-        local checkpointTrigger1 = ents.Create("trigger_once")
-        checkpointTrigger1:SetupTrigger(Vector(-6397.890625, 4632.765625, 512.031250), Angle(0, 0, 0), Vector(-300, -20, 0), Vector(300, 20, 200))
-
-        checkpointTrigger1.OnTrigger = function(_, activator)
-            GAMEMODE:SetVehicleCheckpoint(Vector(-6321.518555, 4750.143066, 532.837036), Angle(0, 180, 0))
-            GAMEMODE:SetPlayerCheckpoint(checkpoint1, activator)
-        end
-
-        -- 8663.506836 11871.029297 -191.968750
-        local checkpoint3 = GAMEMODE:CreateCheckpoint(Vector(8648.458008, 11745.508789, -196.678345), Angle(0, -50, 0))
-        local checkpointTrigger3 = ents.Create("trigger_once")
-        checkpointTrigger3:SetupTrigger(Vector(8663.506836, 11871.029297, -191.968750), Angle(0, 0, 0), Vector(-50, -600, 0), Vector(50, 450, 200))
-
-        checkpointTrigger3.OnTrigger = function(_, activator)
-            GAMEMODE:SetVehicleCheckpoint(Vector(8699.614258, 11645.158203, -192.527618), Angle(0, -90, 0))
-            GAMEMODE:SetPlayerCheckpoint(checkpoint3, activator)
-        end
     end
 end
 


### PR DESCRIPTION
**Work in progress!**

Fixes to default HL2 map scripts.

- Fixed spawnflags on all point_viewcontrol entities in d1_trainstation_01. You could move inside the intro after some time elapsed.
- Refactored all possible checkpoints to use the new format. Checkpoints with additional outputs and conditions are left as is for now.
- Issue #339 has been taken care of.
- Improved some checkpoint positions and corrected loadout additions.
- Fixed #363 and #364 hopefully.


**Notes on certain maps**

canals_08
- Removed 2nd checkpoint since if you'd die and respawn it would be even further away from the dock and airboat.
Or, keep that one but also add another one somewhere (where?)

town_02
- This map is used two times therefore has checkpoints with special conditions (might not be possible with new format)

