### PR TITLE
Corrected r_radiosity convar

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,5 @@
 0.9.30 (in development)
+- Fixed: Bad lightning by forcing r_radiosity convar to 4.
 
 0.9.29
 - Improved: Use new checkpoint structure in mapscripts where possible with better positioning (first 5 chapters).

--- a/gamemode/shared.lua
+++ b/gamemode/shared.lua
@@ -173,6 +173,16 @@ function GM:Initialize()
         self:TransferPlayers()
         self:InitializeResources()
     end
+
+    -- Force r_radiosity to 4 to fix weird lightning 
+    -- GMod's default is 3 unlike every other modern Source game that is set to 4... 
+    if CLIENT then
+        local r_radiosity = GetConVar("r_radiosity")
+        if r_radiosity:GetInt() ~= 4 then
+            print("Changing r_radiosity cvar to 4")
+            RunConsoleCommand("r_radiosity", "4")
+        end
+    end
 end
 
 function GM:OnReloaded()


### PR DESCRIPTION
Since Garry's Mod has r_radiosity set to 3 because some mappers weren't bothered to compile their maps properly, why should we suffer from bad lightning on Half-Life 2 maps. It's not cheat protected, it's not blacklisted from Lua so screw it, lets just set it ourselves. The solution is far from perfect but it is what it is.