### PR TITLE
Fixes barnacle around transition area causing softlock

### DIFF
--- a/gamemode/sv_transition.lua
+++ b/gamemode/sv_transition.lua
@@ -921,7 +921,9 @@ function GM:CreateTransitionObjects()
                 DbgPrint("Using global entity!")
             else
                 ent = ents.Create(data.Class)
-                ent.CreatedByLevelTransition = true
+                if IsValid(ent) then
+                    ent.CreatedByLevelTransition = true
+                end
             end
 
             if not IsValid(ent) then


### PR DESCRIPTION
Barnacle spawn with a internal entity `npc_barnacle_tongue_tip`, and this entity cannot spawn with **`ents.Create()`**, so when there is any barnacles around transition area, after the map changes, Lambda will attempts to re-create said entity, causing null ref error, and player will not be available to spawn, resulting softlock.

Fixes https://github.com/GMLambda/Lambda/issues/385